### PR TITLE
Support installed portable vapoursynth.

### DIFF
--- a/vsrepo.py
+++ b/vsrepo.py
@@ -51,8 +51,8 @@ elif is_sitepackage_install_portable():
     plugin64_path = os.path.join(base_path, 'vapoursynth64', 'plugins')
     del vapoursynth
 else:
-    plugin64_path = os.path.join(os.getenv('APPDATA') + '\\VapourSynth\\plugins32\\'
-    plugin32_path = os.getenv('APPDATA') + '\\VapourSynth\\plugins64\\'
+    plugin32_path = os.path.join(os.getenv('APPDATA') + '\\VapourSynth\\plugins32\\'
+    plugin64_path = os.getenv('APPDATA') + '\\VapourSynth\\plugins64\\'
 
 os.makedirs(py_script_path, exist_ok=True)
 os.makedirs(plugin32_path, exist_ok=True)

--- a/vsrepo.py
+++ b/vsrepo.py
@@ -51,8 +51,8 @@ elif is_sitepackage_install_portable():
     plugin64_path = os.path.join(base_path, 'vapoursynth64', 'plugins')
     del vapoursynth
 else:
-    plugin32_path = os.path.join(os.getenv('APPDATA') + '\\VapourSynth\\plugins32\\'
-    plugin64_path = os.getenv('APPDATA') + '\\VapourSynth\\plugins64\\'
+    plugin32_path = os.path.join(os.getenv('APPDATA'), 'VapourSynth', 'plugins32')
+    plugin64_path = os.path.join(os.getenv('APPDATA'), 'VapourSynth', 'plugins64')
 
 os.makedirs(py_script_path, exist_ok=True)
 os.makedirs(plugin32_path, exist_ok=True)


### PR DESCRIPTION
This will be needed when using the setup.py that will be shipped inside the portable archive of R44.

Also: Portable installations have the `vapourynth32|64\plugins\` directory instead of `VapourSynth\plugins32|64`