### PR TITLE
oyster: Add missing dependency on mvmulti

### DIFF
--- a/local/oyster.json
+++ b/local/oyster.json
@@ -14,7 +14,7 @@
 		"com.vapoursynth.bm3d",
 		"com.holywu.dfttest",
 		"fmtconv",
-		"com.nodame.mvsf"
+		"mvmulti"
 	],
 	"releases": [
 		{


### PR DESCRIPTION
mvmulti also depends on mvsf so I've removed that dependency.