### PR TITLE
Update OS detection. Fix tqdm import on vsrupdate.

### DIFF
--- a/vsrepo.py
+++ b/vsrepo.py
@@ -24,7 +24,6 @@ import sys
 import json
 import hashlib
 import urllib.request
-import platform
 import io
 import site
 import os
@@ -32,19 +31,21 @@ import os.path
 import subprocess
 import tempfile
 import argparse
-import winreg
 import email.utils
 import time
 import zipfile
+
+try:
+    import winreg
+except ImportError:
+    print('{} is only supported on Windows.'.format(__file__))
+    exit(1)
 
 try:
     import tqdm
 except ImportError:
     pass
 
-
-if platform.system() != 'Windows':
-    raise Exception('Windows required')
 
 def is_sitepackage_install_portable():
     try:

--- a/vsrupdate.py
+++ b/vsrupdate.py
@@ -28,15 +28,20 @@ import os.path
 import argparse
 import hashlib
 import subprocess
-import winreg
 import difflib
 import tempfile
-import platform
 import ftplib
-import tqdm
 
-if platform.system() != 'Windows':
-    raise Exception('Windows required')
+try:
+    import winreg
+except ImportError:
+    print('{} is only supported on Windows.'.format(__file__))
+    exit(1)
+
+try:
+    import tqdm
+except ImportError:
+    pass
 
 parser = argparse.ArgumentParser(description='Package list generator for VSRepo')
 parser.add_argument('operation', choices=['compile', 'update-local', 'upload'])


### PR DESCRIPTION
"Solves" https://forum.doom9.org/showthread.php?p=1859600#post1859600

Update Windows/winreg checks for both scripts. The previous OS detection code wasn't working as the winreg module only exists for Python installed on Windows, print a message that's a bit more user friendly afaik this code isn't intended to be imported as a module so the previous exception wasn't (currently) useful.

Fix tqdm import on vsrupdate. Just duplicated the behaviour already in vsrepo.py.