### PR TITLE
Fixes #110

### DIFF
--- a/vsrepo.py
+++ b/vsrepo.py
@@ -104,7 +104,7 @@ os.makedirs(os.path.dirname(package_json_path), exist_ok=True)
 cmd7zip_path = '7z.exe'
 try:
     with winreg.OpenKeyEx(winreg.HKEY_LOCAL_MACHINE, 'SOFTWARE\\7-Zip', reserved=0, access=winreg.KEY_READ) as regkey:
-        cmd7zip_path = winreg.QueryValueEx(regkey, 'Path')[0] + '7z.exe'
+        cmd7zip_path = os.path.join(winreg.QueryValueEx(regkey, 'Path')[0], '7z.exe')
 except:
     pass
 


### PR DESCRIPTION
The bug in #110 is created because his Registry-Value reports "C:\Program Files\7-zip". (Note the missing backslash at the end)

https://github.com/vapoursynth/vsrepo/blob/3d5edfaf0e788ac3b7752d304e972c70c7458d85/vsrepo.py#L107 just adds "7z.exe" to the path, resulting in "C:\Program Files\7-zip7z.exe" which, of course, does not exist throwing an error further down the line.