### PR TITLE
Add vapoursynth.Function to stubs

### DIFF
--- a/vsgenstubs/_vapoursynth.part.pyi
+++ b/vsgenstubs/_vapoursynth.part.pyi
@@ -266,6 +266,8 @@ class AlphaOutputTuple(typing.NamedTuple):
 
 Func = typing.Callable[..., typing.Any]
 
+Function = typing.Callable[..., typing.Any]
+
 class Error(Exception): ...
 
 def set_message_handler(handler_func: typing.Callable[[int, str], None]) -> None: ...


### PR DESCRIPTION
`vapoursynth.Function` is the type for Vapoursynth function (such as `core.std.BlankClip)`
This can be tested quickly with `type(core.std.BlankClip)` in the interpreter.

Without this definition, my IDE gets annoyed when I try to validate input of a function, for example
```python
isinstance(resizer, vs.Function)
```
I did see vs.Func defined, though that doesn't work here.