### PR TITLE
Add feature: updatemode, fetches the latest commit version of a script

### DIFF
--- a/local/havsfunc.json
+++ b/local/havsfunc.json
@@ -8,6 +8,7 @@
 	"identifier": "havsfunc",
 	"modulename": "havsfunc",
 	"github": "https://github.com/HomeOfVapourSynthEvolution/havsfunc",
+	"updatemode": "git-commits",
 	"dependencies": [
 		"mvsfunc",
 		"adjust",

--- a/local/muvsfunc.json
+++ b/local/muvsfunc.json
@@ -7,6 +7,7 @@
 	"identifier": "muvsfunc",
 	"modulename": "muvsfunc",
 	"github": "https://github.com/WolframRhodium/muvsfunc",
+	"updatemode": "git-commits",
 	"dependencies": [
 		"havsfunc",
 		"mvsfunc",


### PR DESCRIPTION
Features & Limitations
- Works out of the box for scripts with releases, but not for raw.githubusercontent.com direct links. Just add "updatemode": "git-commits"
- For the "git path" paramter only files that are not inside a folder(on github) are supported right now (we don't have any anyways)
- The same zipball style is used. Pro: we have access to all files. Con: Guessing the correct "git path" is harder hence no folder support (yet)