### PR TITLE
Fix stray "smart quote" in vivtc.json

### DIFF
--- a/local/vivtc.json
+++ b/local/vivtc.json
@@ -2,7 +2,7 @@
 	"name": "VIVTC",
 	"type": "VSPlugin",
 	"category": "Inverse Telecine",
-	"description": "VIVTC is a set of filters that can be used for inverse telecine. It is a rewrite of some of tritical’s TIVTC filters.",
+	"description": "VIVTC is a set of filters that can be used for inverse telecine. It is a rewrite of some of tritical's TIVTC filters.",
 	"website": "http://www.vapoursynth.com/doc/plugins/vivtc.html",
 	"github": "https://github.com/vapoursynth/vivtc",
 	"identifier": "org.ivtc.v",


### PR DESCRIPTION
I use [VSRepoGUI](https://github.com/theChaosCoder/VSRepoGUI) pretty often and I suspect this character (U+2019 instead of the more typical U+0027) breaks the METADATA file that it creates, forcing ANSI encoding instead of UTF-8 and making pip scream at me until I reencode the file. Not sure which one of these projects is specifically at fault here, but this is an inconsequentially simple fix lol. It'll still be a valid correction even if it ends up being an issue with VSRepoGUI instead of the main vsrepo.