### PR TITLE
fix: name 'pluginparent' is not defined

### DIFF
--- a/vsrepo.py
+++ b/vsrepo.py
@@ -162,6 +162,7 @@ if args.portable:
 elif is_sitepackage_install_portable():
     vapoursynth_path = detect_vapoursynth_installation()
     base_path = os.path.dirname(vapoursynth_path)
+    pluginparent  = os.path.join(base_path, 'vapoursynth64' if is_64bits else 'vapoursynth32')
     plugin32_path = os.path.join(base_path, 'vapoursynth32', 'plugins')
     plugin64_path = os.path.join(base_path, 'vapoursynth64', 'plugins')
     del vapoursynth_path


### PR DESCRIPTION
When using VapourSynth Portable with Python embeded version, `is_sitepackage_install_portable()` returns `True`, so
https://github.com/vapoursynth/vsrepo/blob/1f89e14339122682b7164cd6ce8bc43e4cdb4607/vsrepo.py#L159-L175
will result in `NameError: name 'pluginparent' is not defined` in
https://github.com/vapoursynth/vsrepo/blob/1f89e14339122682b7164cd6ce8bc43e4cdb4607/vsrepo.py#L177

If I use `vsrepo {command} -p`, the installed plugins will be saved to `os.getcwd()/vapoursynth64/plugins` or `{vsrepo_path}/vapoursynth64/plugins` depending on where vsrepo is installed.

Actually, if we define `pluginparent`, we could simply use `vsrepo {command}` without `-p` parameter, at lease the plugins will be installed to `{python_path}/vapoursynth64/plugins`.