### PR TITLE
Fix name 'pluginparent' is not defined in virtualenv Python

### DIFF
--- a/vsrepo.py
+++ b/vsrepo.py
@@ -172,7 +172,7 @@ if (args.operation in ['install', 'upgrade', 'uninstall']) and ((args.package is
     print('Package argument required for install, upgrade and uninstall operations')
     sys.exit(1)
 
-package_json_path = os.path.join(file_dirname, 'vspackages3.json') if args.portable else os.path.join(*pluginparent, 'vsrepo', 'vspackages3.json')
+package_json_path = os.path.join(file_dirname, 'vspackages3.json') if args.portable or is_sitepackage_install_portable() else os.path.join(*pluginparent, 'vsrepo', 'vspackages3.json')
 
 if is_sitepackage_install():
     if is_venv():


### PR DESCRIPTION
Reproduce the issue in Win10:
1. Create a Python virtualenv (`D:\virtual_py3`)
2. Run the activate script(`D:\virtual_py3\Scripts\activate.bat`) to activate virtualenv. Then run `pip install vapoursynth-portable` to install vapoursynth.
3. Run `python vsrepo.py update`
4. Run `python vsrepo.py install lsmas dfttest`. Then an error occurred:
```
Traceback (most recent call last):
  File "D:\virtual_py3\vsrepo\vsrepo.py", line 176, in <module>
    package_json_path = os.path.join(file_dirname, 'vspackages3.json') if args.portable else os.path.join(*pluginparent, 'vsrepo', 'vspackages3.json')
                                                                                                           ^^^^^^^^^^^^
NameError: name 'pluginparent' is not defined
```
We can find the file `portable.vs` in the site-packages dir: `D:\virtual_py3\Lib\site-packages\portable.vs`

```
if args.portable:
    plugin32_path = os.path.join(file_dirname, 'vapoursynth32', 'plugins')
    plugin64_path = os.path.join(file_dirname, 'vapoursynth64', 'plugins')
elif is_sitepackage_install_portable():
    vapoursynth_path = detect_vapoursynth_installation()
    base_path = os.path.dirname(vapoursynth_path)
    plugin32_path = os.path.join(base_path, 'vapoursynth32', 'plugins')
    plugin64_path = os.path.join(base_path, 'vapoursynth64', 'plugins')
    del vapoursynth_path
else:
    pluginparent = [str(os.getenv("APPDATA")), 'VapourSynth']
    plugin32_path = os.path.join(*pluginparent, 'plugins32')
    plugin64_path = os.path.join(*pluginparent, 'plugins64')
```
According to the logic of the code, the statement `elif is_sitepackage_install_portable():` will be entered. But the variable `pluginparent` is not set here. So, the following code will throw an error `NameError: name 'pluginparent' is not defined`.
```
package_json_path = os.path.join(file_dirname, 'vspackages3.json') if args.portable or is_sitepackage_install_portable() else os.path.join(*pluginparent, 'vsrepo', 'vspackages3.json')
```