### PR TITLE
vsrupdate: Allow updates from single repo for all plugins

### DIFF
--- a/local/fftw3_library.json
+++ b/local/fftw3_library.json
@@ -67,6 +67,22 @@
 					]
 				}
 			}
+		},
+		{
+			"version": "0",
+			"published": "1970-01-01T12:00:00Z",
+			"darwin-aarch64": {
+				"url": "ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll32.zip",
+				"files": { }
+			},
+			"darwin-x86_64": {
+				"url": "ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll32.zip",
+				"files": { }
+			},
+			"linux-glibc-x86_64": {
+				"url": "ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll32.zip",
+				"files": { }
+			}
 		}
 	]
 }

--- a/local/nnedi3_weights.json
+++ b/local/nnedi3_weights.json
@@ -26,6 +26,33 @@
 						"27f382430435bb7613deb1c52f3c79c300c9869812cfe29079432a9c82251d42"
 					]
 				}
+			},
+			"darwin-aarch64": {
+				"url": "https://github.com/sekrit-twc/znedi3/releases/download/r1/znedi3_r1.7z",
+				"files": {
+					"nnedi3_weights.bin": [
+						"nnedi3_weights.bin",
+						"27f382430435bb7613deb1c52f3c79c300c9869812cfe29079432a9c82251d42"
+					]
+				}
+			},
+			"darwin-x86_64": {
+				"url": "https://github.com/sekrit-twc/znedi3/releases/download/r1/znedi3_r1.7z",
+				"files": {
+					"nnedi3_weights.bin": [
+						"nnedi3_weights.bin",
+						"27f382430435bb7613deb1c52f3c79c300c9869812cfe29079432a9c82251d42"
+					]
+				}
+			},
+			"linux-glibc-x86_64": {
+				"url": "https://github.com/sekrit-twc/znedi3/releases/download/r1/znedi3_r1.7z",
+				"files": {
+					"nnedi3_weights.bin": [
+						"nnedi3_weights.bin",
+						"27f382430435bb7613deb1c52f3c79c300c9869812cfe29079432a9c82251d42"
+					]
+				}
 			}
 		}
 	]


### PR DESCRIPTION
This adds a `-multi-url` to allow updating all plugins from a single GitHub repository. The plugin is identified by the release tags, which need to be in this format: `vsplugin/{identifier}/{version}/{platform}/*` and should contain only a single asset.

Usage (this is what I did):
```
python3 vsrupdate.py update-local -g [GITHUB_TOKEN] -multi-url https://github.com/Stefan-Olt/vs-plugin-build
```

Builds from the standard plugin repository have higher priority, a release from the multi-plugin repository is only added, if there is no build for that platform and version in the plugin repository.

I also added Linux (and macOS) support to vsrupdate, this is just a few lines to not try getting `7z.exe` path from the registry, but just use `7z` on non-Windows platforms. 

Tested `update-local` (for all plugins) and `compile` of vspackages3.json, worked perfectly, could copy that file and use vsrepo to install plugins just fine.

Additionally:
- Manually updated nnedi3_weights for other platforms (is platform independent, but there is no option for that)
- Manually added version of fftw3_library with no files for non-Windows platforms to fix dependency warning (fftw3 is statically linked into the plugins on Linux/macOS to avoid problems with system-installed versions)