### PR TITLE
Fix gendistinfo

### DIFF
--- a/vsrepo.py
+++ b/vsrepo.py
@@ -410,10 +410,8 @@ def is_package_upgradable(id: str, force: bool) -> bool:
         return (is_package_installed(id) and (lastest_installable is not None) and (installed_packages[id] != 'Unknown') and (installed_packages[id] != lastest_installable['version']))
 
 def get_python_package_name(pkg: MutableMapping) -> str:
-    if "wheelname" in pkg:
-        return pkg["wheelname"].replace(".", "_").replace(" ", "_").replace("(", "_").replace(")", "").replace("_-_", "_")
-    else:
-        return pkg["name"].replace(".", "_").replace(" ", "_").replace("(", "_").replace(")", "").replace("_-_", "_")
+    name = pkg.get("wheelname", pkg["name"])
+    return re.sub(r"[.\s()_\-]+", "_", name).strip("_")
 
 def find_dist_version(pkg: MutableMapping, path: Optional[str]) -> Optional[str]:
     if path is None:


### PR DESCRIPTION
Another attempt to fix #199

pip uses `.partition("-")`
```py
    stem, suffix = os.path.splitext(info_location.name)
    if suffix == ".dist-info":
        name, sep, version = stem.partition("-")
```
https://github.com/pypa/pip/blob/af2d03674bc56de5ed868d722f085bfb711c51c4/src/pip/_internal/metadata/importlib/_compat.py#L64
as such imo. we should not use `-` in the distribution string at all.