### PR TITLE
Fix filename and GitHub links in adjust.json

### DIFF
--- a/local/adjust.json
+++ b/local/adjust.json
@@ -2,21 +2,21 @@
 	"name": "adjust",
 	"type": "PyScript",
 	"description": "A script equivalent of Avisynth's Tweak function",
-	"website": "https://github.com/dubhater/vapoursynth-adjust",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-adjust",
 	"category": "Color/Levels",
 	"identifier": "adjust",
 	"modulename": "adjust",
-	"github": "https://github.com/dubhater/vapoursynth-adjust",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-adjust",
 	"updatemode": "git-commits",
 	"releases": [
 		{
 			"version": "git:a3af7cb",
 			"published": "2021-10-06T12:20:30Z",
 			"script": {
-				"url": "https://api.github.com/repos/dubhater/vapoursynth-adjust/zipball/a3af7cb57cb37747b0667346375536e65b1fed17",
+				"url": "https://api.github.com/repos/dubhatervapoursynth/vapoursynth-adjust/zipball/a3af7cb57cb37747b0667346375536e65b1fed17",
 				"files": {
 					"adjust.py": [
-						"dubhater-vapoursynth-adjust-a3af7cb/adjust.py",
+						"dubhatervapoursynth-vapoursynth-adjust-a3af7cb/adjust.py",
 						"22b25995ef37e6d003c2999e51e80d1570376413db9067f703fe4fcef4600bfa"
 					]
 				}
@@ -26,7 +26,7 @@
 			"version": "v1",
 			"published": "2018-09-06T18:40:51Z",
 			"script": {
-				"url": "https://github.com/dubhater/vapoursynth-adjust/archive/v1.zip",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-adjust/archive/v1.zip",
 				"files": {
 					"adjust.py": [
 						"vapoursynth-adjust-1/adjust.py",


### PR DESCRIPTION
Fix this problem
```
Rebuilding dist-info dirs for other python package installers
Fetching: https://api.github.com/repos/dubhater/vapoursynth-adjust/zipball/a3af7cb57cb37747b0667346375536e65b1fed17
Traceback (most recent call last):
  File "<frozen runpy>", line 189, in _run_module_as_main
  File "<frozen runpy>", line 112, in _get_module_details
  File "G:\Vapoursynth\vapoursynth-portable\vsrepo.py", line 831, in <module>
    res = install_package(name)
  File "G:\Vapoursynth\vapoursynth-portable\vsrepo.py", line 611, in install_package
    res = install_package(dep)
  File "G:\Vapoursynth\vapoursynth-portable\vsrepo.py", line 614, in install_package
    fres = install_files(p)
  File "G:\Vapoursynth\vapoursynth-portable\vsrepo.py", line 579, in install_files
    factory.products[filename].write(archive.read(filename))
                                     ~~~~~~~~~~~~^^^^^^^^^^
  File "zipfile\__init__.py", line 1681, in read
  File "zipfile\__init__.py", line 1718, in open
  File "zipfile\__init__.py", line 1646, in getinfo
KeyError: "There is no item named 'dubhater-vapoursynth-adjust-a3af7cb/adjust.py' in the archive"
```