### PR TITLE
fix: replace "dubhater" with "dubhatervapoursynth" in Gihutb links and filename

### DIFF
--- a/local/asharp.json
+++ b/local/asharp.json
@@ -2,7 +2,7 @@
 	"name": "ASharp",
 	"type": "VSPlugin",
 	"description": "Adaptive sharpening filter",
-	"github": "https://github.com/dubhater/vapoursynth-asharp",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-asharp",
 	"category": "Sharpening",
 	"identifier": "com.nodame.asharp",
 	"namespace": "asharp",
@@ -11,7 +11,7 @@
 			"version": "v1",
 			"published": "2020-05-02T17:05:39Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-asharp/releases/download/v1/vapoursynth-asharp-v1-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-asharp/releases/download/v1/vapoursynth-asharp-v1-win32.7z",
 				"files": {
 					"libasharp.dll": [
 						"libasharp.dll",
@@ -20,7 +20,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-asharp/releases/download/v1/vapoursynth-asharp-v1-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-asharp/releases/download/v1/vapoursynth-asharp-v1-win64.7z",
 				"files": {
 					"libasharp.dll": [
 						"libasharp.dll",

--- a/local/astdr.json
+++ b/local/astdr.json
@@ -2,11 +2,11 @@
 	"name": "ASTDR",
 	"type": "PyScript",
 	"description": "ASTDR is a derainbow function. ASTDRmc performs motion compensation before calling ASTDR",
-	"website": "https://github.com/dubhater/vapoursynth-astdr",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-astdr",
 	"category": "Dot Crawl and Rainbows",
 	"identifier": "ASTDR",
 	"modulename": "ASTDR",
-	"github": "https://github.com/dubhater/vapoursynth-astdr",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-astdr",
 	"dependencies": [
 		"adjust",
 		"chikuzen.does.not.have.his.own.domain.focus2",
@@ -25,10 +25,10 @@
 			"version": "v4",
 			"published": "2022-07-14T16:32:41Z",
 			"script": {
-				"url": "https://api.github.com/repos/dubhater/vapoursynth-astdr/zipball/v4",
+				"url": "https://api.github.com/repos/dubhatervapoursynth/vapoursynth-astdr/zipball/v4",
 				"files": {
 					"ASTDR.py": [
-						"dubhater-vapoursynth-astdr-fde2c98/ASTDR.py",
+						"dubhatervapoursynth-vapoursynth-astdr-fde2c98/ASTDR.py",
 						"2c22c71b21c25557f6aba2739c584388d8c1d6a004a3c367a71212db14418694"
 					]
 				}
@@ -38,10 +38,10 @@
 			"version": "v3",
 			"published": "2020-07-30T11:49:39Z",
 			"script": {
-				"url": "https://api.github.com/repos/dubhater/vapoursynth-astdr/zipball/v3",
+				"url": "https://api.github.com/repos/dubhatervapoursynth/vapoursynth-astdr/zipball/v3",
 				"files": {
 					"ASTDR.py": [
-						"dubhater-vapoursynth-astdr-69ded1f/ASTDR.py",
+						"dubhatervapoursynth-vapoursynth-astdr-69ded1f/ASTDR.py",
 						"47beaa99c80f0507d1064af5a49d718f4935f04f055bf8aa40daf3919b28dae8"
 					]
 				}
@@ -51,10 +51,10 @@
 			"version": "v2",
 			"published": "2018-11-29T20:08:34Z",
 			"script": {
-				"url": "https://api.github.com/repos/dubhater/vapoursynth-astdr/zipball/v2",
+				"url": "https://api.github.com/repos/dubhatervapoursynth/vapoursynth-astdr/zipball/v2",
 				"files": {
 					"ASTDR.py": [
-						"dubhater-vapoursynth-astdr-cb72b97/ASTDR.py",
+						"dubhatervapoursynth-vapoursynth-astdr-cb72b97/ASTDR.py",
 						"fb1429f5243f5ff919379a80c883745d4e8c40fcc8d8d762d8bd0c76e55d09f0"
 					]
 				}
@@ -64,10 +64,10 @@
 			"version": "v1",
 			"published": "2018-09-06T17:56:05Z",
 			"script": {
-				"url": "https://api.github.com/repos/dubhater/vapoursynth-astdr/zipball/v1",
+				"url": "https://api.github.com/repos/dubhatervapoursynth/vapoursynth-astdr/zipball/v1",
 				"files": {
 					"ASTDR.py": [
-						"dubhater-vapoursynth-astdr-969fd06/ASTDR.py",
+						"dubhatervapoursynth-vapoursynth-astdr-969fd06/ASTDR.py",
 						"f812b202ee698e5c9d65c560881c909ac9b2451a07a336796c9e8a2b3a3434b6"
 					]
 				}

--- a/local/awarp.json
+++ b/local/awarp.json
@@ -2,7 +2,7 @@
 	"name": "AWarp",
 	"type": "VSPlugin",
 	"category": "Other",
-	"description": "AWarp filter modified from https://github.com/dubhater/vapoursynth-awarpsharp2",
+	"description": "AWarp filter modified from https://github.com/dubhatervapoursynth/vapoursynth-awarpsharp2",
 	"github": "https://github.com/HolyWu/VapourSynth-AWarp",
 	"pypiname": "vapoursynth-awarp",
 	"identifier": "com.holywu.awarp",

--- a/local/bifrost.json
+++ b/local/bifrost.json
@@ -2,18 +2,18 @@
 	"name": "Bifrost",
 	"type": "VSPlugin",
 	"description": "A rainbow remover based on the Bifrost filter for Avisynth",
-	"website": "https://github.com/dubhater/vapoursynth-bifrost",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-bifrost",
 	"doom9": "https://forum.doom9.org/showthread.php?t=169758",
 	"category": "Dot Crawl and Rainbows",
 	"identifier": "com.nodame.bifrost",
 	"namespace": "bifrost",
-	"github": "https://github.com/dubhater/vapoursynth-bifrost",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-bifrost",
 	"releases": [
 		{
 			"version": "v3.0",
 			"published": "2024-05-08T20:21:32Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-bifrost/releases/download/v3.0/Bifrost-3.0.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-bifrost/releases/download/v3.0/Bifrost-3.0.7z",
 				"files": {
 					"bifrost.dll": [
 						"x86/bifrost.dll",
@@ -22,7 +22,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-bifrost/releases/download/v3.0/Bifrost-3.0.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-bifrost/releases/download/v3.0/Bifrost-3.0.7z",
 				"files": {
 					"bifrost.dll": [
 						"x64/bifrost.dll",
@@ -62,7 +62,7 @@
 			"version": "v2.2",
 			"published": "2014-05-16T09:05:10Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-bifrost/releases/download/v2.2/vapoursynth-bifrost-v2.2-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-bifrost/releases/download/v2.2/vapoursynth-bifrost-v2.2-win32.7z",
 				"files": {
 					"libbifrost.dll": [
 						"libbifrost.dll",
@@ -71,7 +71,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-bifrost/releases/download/v2.2/vapoursynth-bifrost-v2.2-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-bifrost/releases/download/v2.2/vapoursynth-bifrost-v2.2-win64.7z",
 				"files": {
 					"libbifrost.dll": [
 						"libbifrost.dll",
@@ -84,7 +84,7 @@
 			"version": "v2.1",
 			"published": "2013-12-02T14:01:44Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-bifrost/releases/download/v2.1/vapoursynth-bifrost-v2.1-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-bifrost/releases/download/v2.1/vapoursynth-bifrost-v2.1-win32.7z",
 				"files": {
 					"libbifrost.dll": [
 						"libbifrost.dll",
@@ -93,7 +93,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-bifrost/releases/download/v2.1/vapoursynth-bifrost-v2.1-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-bifrost/releases/download/v2.1/vapoursynth-bifrost-v2.1-win64.7z",
 				"files": {
 					"libbifrost.dll": [
 						"libbifrost.dll",
@@ -110,7 +110,7 @@
 			"version": "v2.0",
 			"published": "2013-11-09T14:45:17Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-bifrost/releases/download/v2.0/vapoursynth-bifrost-v2.0-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-bifrost/releases/download/v2.0/vapoursynth-bifrost-v2.0-win32.7z",
 				"files": {
 					"libbifrost.dll": [
 						"libbifrost.dll",
@@ -119,7 +119,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-bifrost/releases/download/v2.0/vapoursynth-bifrost-v2.0-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-bifrost/releases/download/v2.0/vapoursynth-bifrost-v2.0-win64.7z",
 				"files": {
 					"libbifrost.dll": [
 						"libbifrost.dll",

--- a/local/cnr2.json
+++ b/local/cnr2.json
@@ -2,18 +2,18 @@
 	"name": "Cnr2",
 	"type": "VSPlugin",
 	"description": "Temporal chroma noise reducer",
-	"website": "https://github.com/dubhater/vapoursynth-cnr2",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-cnr2",
 	"doom9": "https://forum.doom9.org/showthread.php?t=173659",
 	"category": "Denoising",
 	"identifier": "com.nodame.cnr2",
 	"namespace": "cnr2",
-	"github": "https://github.com/dubhater/vapoursynth-cnr2",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-cnr2",
 	"releases": [
 		{
 			"version": "v1",
 			"published": "2016-07-02T18:42:33Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-cnr2/releases/download/v1/vapoursynth-cnr2-v1-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-cnr2/releases/download/v1/vapoursynth-cnr2-v1-win32.7z",
 				"files": {
 					"libcnr2.dll": [
 						"libcnr2.dll",
@@ -22,7 +22,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-cnr2/releases/download/v1/vapoursynth-cnr2-v1-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-cnr2/releases/download/v1/vapoursynth-cnr2-v1-win64.7z",
 				"files": {
 					"libcnr2.dll": [
 						"libcnr2.dll",

--- a/local/damb.json
+++ b/local/damb.json
@@ -2,8 +2,8 @@
 	"name": "damb",
 	"type": "VSPlugin",
 	"description": "Audio file reader and writer",
-	"website": "https://github.com/dubhater/vapoursynth-damb",
-	"github": "https://github.com/dubhater/vapoursynth-damb",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-damb",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-damb",
 	"doom9": " https://forum.doom9.org/showthread.php?t=171555",
 	"category": "Other",
 	"identifier": "com.nodame.damb",
@@ -13,7 +13,7 @@
 			"version": "v3",
 			"published": "2015-02-06T12:25:58Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-damb/releases/download/v3/vapoursynth-damb-v3-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-damb/releases/download/v3/vapoursynth-damb-v3-win32.7z",
 				"files": {
 					"libdamb.dll": [
 						"libdamb.dll",
@@ -22,7 +22,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-damb/releases/download/v3/vapoursynth-damb-v3-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-damb/releases/download/v3/vapoursynth-damb-v3-win64.7z",
 				"files": {
 					"libdamb.dll": [
 						"libdamb.dll",
@@ -35,7 +35,7 @@
 			"version": "v2",
 			"published": "2014-12-29T09:54:49Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-damb/releases/download/v2/vapoursynth-damb-v2-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-damb/releases/download/v2/vapoursynth-damb-v2-win32.7z",
 				"files": {
 					"libdamb.dll": [
 						"libdamb.dll",
@@ -44,7 +44,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-damb/releases/download/v2/vapoursynth-damb-v2-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-damb/releases/download/v2/vapoursynth-damb-v2-win64.7z",
 				"files": {
 					"libdamb.dll": [
 						"libdamb.dll",
@@ -57,7 +57,7 @@
 			"version": "v1",
 			"published": "2014-12-16T19:17:23Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-damb/releases/download/v1/vapoursynth-damb-v1-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-damb/releases/download/v1/vapoursynth-damb-v1-win32.7z",
 				"files": {
 					"libdamb.dll": [
 						"libdamb.dll",
@@ -66,7 +66,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-damb/releases/download/v1/vapoursynth-damb-v1-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-damb/releases/download/v1/vapoursynth-damb-v1-win64.7z",
 				"files": {
 					"libdamb.dll": [
 						"libdamb.dll",

--- a/local/decross.json
+++ b/local/decross.json
@@ -2,18 +2,18 @@
 	"name": "DeCross",
 	"type": "VSPlugin",
 	"description": "DeCross is a spatio-temporal cross color (rainbow) reduction filter",
-	"website": "https://github.com/dubhater/vapoursynth-decross",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-decross",
 	"doom9": "https://forum.doom9.org/showthread.php?t=175527",
 	"category": "Dot Crawl and Rainbows",
 	"identifier": "com.nodame.decross",
 	"namespace": "decross",
-	"github": "https://github.com/dubhater/vapoursynth-decross",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-decross",
 	"releases": [
 		{
 			"version": "v1",
 			"published": "2018-06-13T11:18:18Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-decross/releases/download/v1/vapoursynth-decross-v1-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-decross/releases/download/v1/vapoursynth-decross-v1-win32.7z",
 				"files": {
 					"libdecross.dll": [
 						"libdecross.dll",
@@ -22,7 +22,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-decross/releases/download/v1/vapoursynth-decross-v1-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-decross/releases/download/v1/vapoursynth-decross-v1-win64.7z",
 				"files": {
 					"libdecross.dll": [
 						"libdecross.dll",

--- a/local/dedot.json
+++ b/local/dedot.json
@@ -2,17 +2,17 @@
 	"name": "DeDot",
 	"type": "VSPlugin",
 	"description": "Dedot is a temporal cross color (rainbow) and cross luminance (dotcrawl) reduction filter.",
-	"website": "https://github.com/dubhater/vapoursynth-dedot",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-dedot",
 	"category": "Dot Crawl and Rainbows",
 	"identifier": "com.nodame.dedot",
 	"namespace": "dedot",
-	"github": "https://github.com/dubhater/vapoursynth-dedot",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-dedot",
 	"releases": [
 		{
 			"version": "v1",
 			"published": "2018-08-04T19:41:01Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-dedot/releases/download/v1/vapoursynth-dedot-v1-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-dedot/releases/download/v1/vapoursynth-dedot-v1-win32.7z",
 				"files": {
 					"libdedot.dll": [
 						"libdedot.dll",
@@ -21,7 +21,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-dedot/releases/download/v1/vapoursynth-dedot-v1-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-dedot/releases/download/v1/vapoursynth-dedot-v1-win64.7z",
 				"files": {
 					"libdedot.dll": [
 						"libdedot.dll",

--- a/local/dfmderainbow.json
+++ b/local/dfmderainbow.json
@@ -2,11 +2,11 @@
 	"name": "DFMDerainbow",
 	"type": "PyScript",
 	"description": "DFMDerainbow is a derainbow function. DFMDerainbowMC performs motion compensation before calling DFMDerainbow.",
-	"website": "https://github.com/dubhater/vapoursynth-dfmderainbow",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-dfmderainbow",
 	"category": "Dot Crawl and Rainbows",
 	"identifier": "dfmderainbow",
 	"modulename": "dfmderainbow",
-	"github": "https://github.com/dubhater/vapoursynth-dfmderainbow",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-dfmderainbow",
 	"updatemode": "git-commits",
 	"dependencies": [
 		"com.nodame.temporalmedian",
@@ -22,10 +22,10 @@
 			"version": "git:44dc654",
 			"published": "2022-10-17T09:55:32Z",
 			"script": {
-				"url": "https://api.github.com/repos/dubhater/vapoursynth-dfmderainbow/zipball/44dc6545bced8fc25672bdda717943a02c6b5d71",
+				"url": "https://api.github.com/repos/dubhatervapoursynth/vapoursynth-dfmderainbow/zipball/44dc6545bced8fc25672bdda717943a02c6b5d71",
 				"files": {
 					"dfmderainbow.py": [
-						"dubhater-vapoursynth-dfmderainbow-44dc654/dfmderainbow.py",
+						"dubhatervapoursynth-vapoursynth-dfmderainbow-44dc654/dfmderainbow.py",
 						"fdf037e63100b8388cfdc194a72e14338fcc3faf286550161020578b9a125f24"
 					]
 				}
@@ -35,10 +35,10 @@
 			"version": "git:61bafd9",
 			"published": "2022-02-05T14:17:35Z",
 			"script": {
-				"url": "https://api.github.com/repos/dubhater/vapoursynth-dfmderainbow/zipball/61bafd9b3f4fa7839038c1a160382ab18fdb152b",
+				"url": "https://api.github.com/repos/dubhatervapoursynth/vapoursynth-dfmderainbow/zipball/61bafd9b3f4fa7839038c1a160382ab18fdb152b",
 				"files": {
 					"dfmderainbow.py": [
-						"dubhater-vapoursynth-dfmderainbow-61bafd9/dfmderainbow.py",
+						"dubhatervapoursynth-vapoursynth-dfmderainbow-61bafd9/dfmderainbow.py",
 						"06992dd0c4d31e53825b1a2bad05a5c62c882bc801387fb0ad482f83019f5a0d"
 					]
 				}
@@ -48,10 +48,10 @@
 			"version": "v2",
 			"published": "2019-02-15T15:46:04Z",
 			"script": {
-				"url": "https://api.github.com/repos/dubhater/vapoursynth-dfmderainbow/zipball/v2",
+				"url": "https://api.github.com/repos/dubhatervapoursynth/vapoursynth-dfmderainbow/zipball/v2",
 				"files": {
 					"dfmderainbow.py": [
-						"dubhater-vapoursynth-dfmderainbow-826ed41/dfmderainbow.py",
+						"dubhatervapoursynth-vapoursynth-dfmderainbow-826ed41/dfmderainbow.py",
 						"54f65c5162932e9d8f306ec59d8e23878bc97cd09529f563d3d6d74d8dd58a34"
 					]
 				}
@@ -61,10 +61,10 @@
 			"version": "v1",
 			"published": "2018-09-06T18:00:58Z",
 			"script": {
-				"url": "https://api.github.com/repos/dubhater/vapoursynth-dfmderainbow/zipball/v1",
+				"url": "https://api.github.com/repos/dubhatervapoursynth/vapoursynth-dfmderainbow/zipball/v1",
 				"files": {
 					"dfmderainbow.py": [
-						"dubhater-vapoursynth-dfmderainbow-2c68baa/dfmderainbow.py",
+						"dubhatervapoursynth-vapoursynth-dfmderainbow-2c68baa/dfmderainbow.py",
 						"9421618a04ec7dec49c72c0fe8fc55b8e3ee6988890545c3d55f7b839fdcbaed"
 					]
 				}

--- a/local/dgm.json
+++ b/local/dgm.json
@@ -2,18 +2,18 @@
 	"name": "degrainmedian",
 	"type": "VSPlugin",
 	"description": "Spatio-temporal limited median denoiser",
-	"website": "https://github.com/dubhater/vapoursynth-degrainmedian",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-degrainmedian",
 	"doom9": "https://forum.doom9.org/showthread.php?t=173758",
 	"category": "Denoising",
 	"identifier": "com.nodame.degrainmedian",
 	"namespace": "dgm",
-	"github": "https://github.com/dubhater/vapoursynth-degrainmedian",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-degrainmedian",
 	"releases": [
 		{
 			"version": "v1",
 			"published": "2016-08-07T17:58:40Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-degrainmedian/releases/download/v1/vapoursynth-degrainmedian-v1-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-degrainmedian/releases/download/v1/vapoursynth-degrainmedian-v1-win32.7z",
 				"files": {
 					"libdegrainmedian.dll": [
 						"libdegrainmedian.dll",
@@ -22,7 +22,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-degrainmedian/releases/download/v1/vapoursynth-degrainmedian-v1-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-degrainmedian/releases/download/v1/vapoursynth-degrainmedian-v1-win64.7z",
 				"files": {
 					"libdegrainmedian.dll": [
 						"libdegrainmedian.dll",

--- a/local/fb.json
+++ b/local/fb.json
@@ -2,17 +2,17 @@
 	"name": "fillborders",
 	"type": "VSPlugin",
 	"description": "A simple filter that fills the borders of a clip, without changing the clip's dimensions",
-	"website": "https://github.com/dubhater/vapoursynth-fillborders",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-fillborders",
 	"category": "Other",
 	"identifier": "com.nodame.fillborders",
 	"namespace": "fb",
-	"github": "https://github.com/dubhater/vapoursynth-fillborders",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-fillborders",
 	"releases": [
 		{
 			"version": "v2",
 			"published": "2021-01-26T15:05:53Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-fillborders/releases/download/v2/vapoursynth-fillborders-v2-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-fillborders/releases/download/v2/vapoursynth-fillborders-v2-win32.7z",
 				"files": {
 					"libfillborders.dll": [
 						"libfillborders.dll",
@@ -21,7 +21,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-fillborders/releases/download/v2/vapoursynth-fillborders-v2-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-fillborders/releases/download/v2/vapoursynth-fillborders-v2-win64.7z",
 				"files": {
 					"libfillborders.dll": [
 						"libfillborders.dll",
@@ -61,7 +61,7 @@
 			"version": "v1.0",
 			"published": "2013-12-15T14:58:20Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-fillborders/releases/download/v1.0/vapoursynth-fillborders-v1.0-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-fillborders/releases/download/v1.0/vapoursynth-fillborders-v1.0-win32.7z",
 				"files": {
 					"libfillborders.dll": [
 						"libfillborders.dll",
@@ -70,7 +70,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-fillborders/releases/download/v1.0/vapoursynth-fillborders-v1.0-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-fillborders/releases/download/v1.0/vapoursynth-fillborders-v1.0-win64.7z",
 				"files": {
 					"libfillborders.dll": [
 						"libfillborders.dll",

--- a/local/fh.json
+++ b/local/fh.json
@@ -2,8 +2,8 @@
 	"name": "FieldHint",
 	"type": "VSPlugin",
 	"description": "FieldHint Plugin",
-	"website": "https://github.com/dubhater/vapoursynth-fieldhint",
-	"github": "https://github.com/dubhater/vapoursynth-fieldhint",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-fieldhint",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-fieldhint",
 	"category": "Other",
 	"identifier": "com.nodame.fieldhint",
 	"namespace": "fh",
@@ -12,7 +12,7 @@
 			"version": "v3",
 			"published": "2015-08-18T20:18:55Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-fieldhint/releases/download/v3/vapoursynth-fieldhint-v3-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-fieldhint/releases/download/v3/vapoursynth-fieldhint-v3-win32.7z",
 				"files": {
 					"libfieldhint.dll": [
 						"libfieldhint.dll",
@@ -21,7 +21,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-fieldhint/releases/download/v3/vapoursynth-fieldhint-v3-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-fieldhint/releases/download/v3/vapoursynth-fieldhint-v3-win64.7z",
 				"files": {
 					"libfieldhint.dll": [
 						"libfieldhint.dll",
@@ -61,7 +61,7 @@
 			"version": "v2",
 			"published": "2015-06-20T21:12:21Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-fieldhint/releases/download/v2/vapoursynth-fieldhint-v2-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-fieldhint/releases/download/v2/vapoursynth-fieldhint-v2-win32.7z",
 				"files": {
 					"libfieldhint.dll": [
 						"libfieldhint.dll",
@@ -70,7 +70,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-fieldhint/releases/download/v2/vapoursynth-fieldhint-v2-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-fieldhint/releases/download/v2/vapoursynth-fieldhint-v2-win64.7z",
 				"files": {
 					"libfieldhint.dll": [
 						"libfieldhint.dll",
@@ -83,7 +83,7 @@
 			"version": "v1.0",
 			"published": "2013-10-01T08:58:49Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-fieldhint/releases/download/v1.0/vapoursynth-fieldhint-v1.0-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-fieldhint/releases/download/v1.0/vapoursynth-fieldhint-v1.0-win32.7z",
 				"files": {
 					"libfieldhint.dll": [
 						"libfieldhint.dll",
@@ -92,7 +92,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-fieldhint/releases/download/v1.0/vapoursynth-fieldhint-v1.0-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-fieldhint/releases/download/v1.0/vapoursynth-fieldhint-v1.0-win64.7z",
 				"files": {
 					"libfieldhint.dll": [
 						"libfieldhint.dll",

--- a/local/flux.json
+++ b/local/flux.json
@@ -2,18 +2,18 @@
 	"name": "FluxSmooth",
 	"type": "VSPlugin",
 	"description": "Temporal-spatiotemporal denoiser",
-	"website": "https://github.com/dubhater/vapoursynth-fluxsmooth",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-fluxsmooth",
 	"doom9": "https://forum.doom9.org/showthread.php?t=173795",
 	"category": "Denoising",
 	"identifier": "com.nodame.fluxsmooth",
 	"namespace": "flux",
-	"github": "https://github.com/dubhater/vapoursynth-fluxsmooth",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-fluxsmooth",
 	"releases": [
 		{
 			"version": "v2",
 			"published": "2016-08-20T09:53:52Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-fluxsmooth/releases/download/v2/vapoursynth-fluxsmooth-v2-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-fluxsmooth/releases/download/v2/vapoursynth-fluxsmooth-v2-win32.7z",
 				"files": {
 					"libfluxsmooth.dll": [
 						"libfluxsmooth.dll",
@@ -22,7 +22,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-fluxsmooth/releases/download/v2/vapoursynth-fluxsmooth-v2-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-fluxsmooth/releases/download/v2/vapoursynth-fluxsmooth-v2-win64.7z",
 				"files": {
 					"libfluxsmooth.dll": [
 						"libfluxsmooth.dll",
@@ -62,7 +62,7 @@
 			"version": "v1.0",
 			"published": "2014-04-06T15:37:35Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-fluxsmooth/releases/download/v1.0/vapoursynth-fluxsmooth-v1.0-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-fluxsmooth/releases/download/v1.0/vapoursynth-fluxsmooth-v1.0-win32.7z",
 				"files": {
 					"libfluxsmooth.dll": [
 						"libfluxsmooth.dll",
@@ -71,7 +71,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-fluxsmooth/releases/download/v1.0/vapoursynth-fluxsmooth-v1.0-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-fluxsmooth/releases/download/v1.0/vapoursynth-fluxsmooth-v1.0-win64.7z",
 				"files": {
 					"libfluxsmooth.dll": [
 						"libfluxsmooth.dll",

--- a/local/focus2.json
+++ b/local/focus2.json
@@ -2,17 +2,17 @@
 	"name": "TemporalSoften2",
 	"type": "VSPlugin",
 	"description": "Remove noise from a video clip by selectively blending pixels",
-	"website": "https://github.com/dubhater/vapoursynth-temporalsoften2",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-temporalsoften2",
 	"category": "Denoising",
 	"identifier": "chikuzen.does.not.have.his.own.domain.focus2",
 	"namespace": "focus2",
-	"github": "https://github.com/dubhater/vapoursynth-temporalsoften2",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-temporalsoften2",
 	"releases": [
 		{
 			"version": "v1",
 			"published": "2018-07-03T19:46:56Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-temporalsoften2/releases/download/v1/vapoursynth-temporalsoften2-v1-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-temporalsoften2/releases/download/v1/vapoursynth-temporalsoften2-v1-win32.7z",
 				"files": {
 					"libtemporalsoften2.dll": [
 						"libtemporalsoften2.dll",
@@ -21,7 +21,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-temporalsoften2/releases/download/v1/vapoursynth-temporalsoften2-v1-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-temporalsoften2/releases/download/v1/vapoursynth-temporalsoften2-v1-win64.7z",
 				"files": {
 					"libtemporalsoften2.dll": [
 						"libtemporalsoften2.dll",

--- a/local/frfun7.json
+++ b/local/frfun7.json
@@ -3,7 +3,7 @@
 	"type": "VSPlugin",
 	"category": "Denoising",
 	"description": "Frfun7 is a spatial fractal denoising filter",
-	"github": "https://github.com/dubhater/vapoursynth-frfun7",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-frfun7",
 	"identifier": "com.nodame.frfun7",
 	"namespace": "frfun7",
 	"releases": [
@@ -11,7 +11,7 @@
 			"version": "v2",
 			"published": "2022-07-01T21:05:24Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-frfun7/releases/download/v2/vapoursynth-frfun7-v2-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-frfun7/releases/download/v2/vapoursynth-frfun7-v2-win32.7z",
 				"files": {
 					"libfrfun7.dll": [
 						"libfrfun7.dll",
@@ -20,7 +20,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-frfun7/releases/download/v2/vapoursynth-frfun7-v2-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-frfun7/releases/download/v2/vapoursynth-frfun7-v2-win64.7z",
 				"files": {
 					"libfrfun7.dll": [
 						"libfrfun7.dll",
@@ -60,7 +60,7 @@
 			"version": "v1",
 			"published": "2022-05-17T20:21:40Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-frfun7/releases/download/v1/vapoursynth-frfun7-v1-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-frfun7/releases/download/v1/vapoursynth-frfun7-v1-win32.7z",
 				"files": {
 					"libfrfun7.dll": [
 						"libfrfun7.dll",
@@ -69,7 +69,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-frfun7/releases/download/v1/vapoursynth-frfun7-v1-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-frfun7/releases/download/v1/vapoursynth-frfun7-v1-win64.7z",
 				"files": {
 					"libfrfun7.dll": [
 						"libfrfun7.dll",

--- a/local/hist.json
+++ b/local/hist.json
@@ -3,7 +3,7 @@
 	"type": "VSPlugin",
 	"category": "Other",
 	"description": "Port of the Histogram() function from Avisynth.",
-	"github": "https://github.com/dubhater/vapoursynth-histogram",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-histogram",
 	"identifier": "com.nodame.histogram",
 	"namespace": "hist",
 	"releases": [
@@ -11,7 +11,7 @@
 			"version": "v2",
 			"published": "2018-06-07T17:49:53Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-histogram/releases/download/v2/vapoursynth-histogram-v2-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-histogram/releases/download/v2/vapoursynth-histogram-v2-win32.7z",
 				"files": {
 					"libhistogram.dll": [
 						"libhistogram.dll",
@@ -20,7 +20,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-histogram/releases/download/v2/vapoursynth-histogram-v2-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-histogram/releases/download/v2/vapoursynth-histogram-v2-win64.7z",
 				"files": {
 					"libhistogram.dll": [
 						"libhistogram.dll",
@@ -60,7 +60,7 @@
 			"version": "v1.0",
 			"published": "2013-10-01T09:08:06Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-histogram/releases/download/v1.0/vapoursynth-histogram-v1.0-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-histogram/releases/download/v1.0/vapoursynth-histogram-v1.0-win32.7z",
 				"files": {
 					"libhistogram.dll": [
 						"libhistogram.dll",
@@ -69,7 +69,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-histogram/releases/download/v1.0/vapoursynth-histogram-v1.0-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-histogram/releases/download/v1.0/vapoursynth-histogram-v1.0-win64.7z",
 				"files": {
 					"libhistogram.dll": [
 						"libhistogram.dll",

--- a/local/limitedsharpen2.json
+++ b/local/limitedsharpen2.json
@@ -2,7 +2,7 @@
 	"name": "LimitedSharpen2",
 	"type": "PyScript",
 	"description": "LimitedSharpen2 is a multipurpose sharpening function",
-	"github": "https://github.com/dubhater/vapoursynth-limitedsharpen2",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-limitedsharpen2",
 	"category": "Sharpening",
 	"identifier": "limitedsharpen2",
 	"modulename": "limitedsharpen2",
@@ -16,10 +16,10 @@
 			"version": "v2",
 			"published": "2020-05-02T17:29:42Z",
 			"script": {
-				"url": "https://api.github.com/repos/dubhater/vapoursynth-limitedsharpen2/zipball/v2",
+				"url": "https://api.github.com/repos/dubhatervapoursynth/vapoursynth-limitedsharpen2/zipball/v2",
 				"files": {
 					"LimitedSharpen2.py": [
-						"dubhater-vapoursynth-limitedsharpen2-7b64d53/LimitedSharpen2.py",
+						"dubhatervapoursynth-vapoursynth-limitedsharpen2-7b64d53/LimitedSharpen2.py",
 						"6de3acb654f8cef69dee3e9ac2f1563c51312789fe3a325ee3ad9b3f7fab80c4"
 					]
 				}
@@ -29,10 +29,10 @@
 			"version": "v1",
 			"published": "2020-05-02T17:15:58Z",
 			"script": {
-				"url": "https://api.github.com/repos/dubhater/vapoursynth-limitedsharpen2/zipball/v1",
+				"url": "https://api.github.com/repos/dubhatervapoursynth/vapoursynth-limitedsharpen2/zipball/v1",
 				"files": {
 					"LimitedSharpen2.py": [
-						"dubhater-vapoursynth-limitedsharpen2-dd81555/LimitedSharpen2.py",
+						"dubhatervapoursynth-vapoursynth-limitedsharpen2-dd81555/LimitedSharpen2.py",
 						"67d6d39c2932b7ff59432ff74b724da6ab94afe87a016b09aa73b5c4c03a5cba"
 					]
 				}

--- a/local/matchhist.json
+++ b/local/matchhist.json
@@ -2,7 +2,7 @@
 	"name": "MatchHistogram",
 	"type": "VSPlugin",
 	"description": "MatchHistogram modifies one clip's histogram to match the histogram of another clip. Will produce weird results if frame contents are dissimilar.",
-	"github": "https://github.com/dubhater/vapoursynth-matchhistogram",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-matchhistogram",
 	"category": "Color/Levels",
 	"identifier": "com.nodame.matchhistogram",
 	"namespace": "matchhist",
@@ -11,7 +11,7 @@
 			"version": "v2",
 			"published": "2019-09-07T19:01:41Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-matchhistogram/releases/download/v2/vapoursynth-matchhistogram-v2-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-matchhistogram/releases/download/v2/vapoursynth-matchhistogram-v2-win32.7z",
 				"files": {
 					"libmatchhistogram.dll": [
 						"libmatchhistogram.dll",
@@ -20,7 +20,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-matchhistogram/releases/download/v2/vapoursynth-matchhistogram-v2-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-matchhistogram/releases/download/v2/vapoursynth-matchhistogram-v2-win64.7z",
 				"files": {
 					"libmatchhistogram.dll": [
 						"libmatchhistogram.dll",
@@ -60,7 +60,7 @@
 			"version": "v1",
 			"published": "2019-09-06T14:01:29Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-matchhistogram/releases/download/v1/vapoursynth-matchhistogram-v1-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-matchhistogram/releases/download/v1/vapoursynth-matchhistogram-v1-win32.7z",
 				"files": {
 					"libmatchhistogram.dll": [
 						"libmatchhistogram.dll",
@@ -69,7 +69,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-matchhistogram/releases/download/v1/vapoursynth-matchhistogram-v1-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-matchhistogram/releases/download/v1/vapoursynth-matchhistogram-v1-win64.7z",
 				"files": {
 					"libmatchhistogram.dll": [
 						"libmatchhistogram.dll",

--- a/local/median.json
+++ b/local/median.json
@@ -2,7 +2,7 @@
 	"name": "Median",
 	"type": "VSPlugin",
 	"description": "",
-	"github": "https://github.com/dubhater/vapoursynth-median",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-median",
 	"category": "Other",
 	"identifier": "com.nodame.median",
 	"namespace": "median",
@@ -11,7 +11,7 @@
 			"version": "v4",
 			"published": "2019-05-10T17:14:38Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-median/releases/download/v4/vapoursynth-median-v4-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-median/releases/download/v4/vapoursynth-median-v4-win32.7z",
 				"files": {
 					"libmedian.dll": [
 						"libmedian.dll",
@@ -20,7 +20,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-median/releases/download/v4/vapoursynth-median-v4-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-median/releases/download/v4/vapoursynth-median-v4-win64.7z",
 				"files": {
 					"libmedian.dll": [
 						"libmedian.dll",
@@ -60,7 +60,7 @@
 			"version": "v3",
 			"published": "2019-05-05T19:17:43Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-median/releases/download/v3/vapoursynth-median-v3-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-median/releases/download/v3/vapoursynth-median-v3-win32.7z",
 				"files": {
 					"libmedian.dll": [
 						"libmedian.dll",
@@ -69,7 +69,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-median/releases/download/v3/vapoursynth-median-v3-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-median/releases/download/v3/vapoursynth-median-v3-win64.7z",
 				"files": {
 					"libmedian.dll": [
 						"libmedian.dll",
@@ -82,7 +82,7 @@
 			"version": "v2",
 			"published": "2019-04-26T19:04:51Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-median/releases/download/v2/vapoursynth-median-v2-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-median/releases/download/v2/vapoursynth-median-v2-win32.7z",
 				"files": {
 					"libmedian.dll": [
 						"libmedian.dll",
@@ -91,7 +91,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-median/releases/download/v2/vapoursynth-median-v2-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-median/releases/download/v2/vapoursynth-median-v2-win64.7z",
 				"files": {
 					"libmedian.dll": [
 						"libmedian.dll",
@@ -104,7 +104,7 @@
 			"version": "v1",
 			"published": "2019-04-25T17:10:52Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-median/releases/download/v1/vapoursynth-median-v1-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-median/releases/download/v1/vapoursynth-median-v1-win32.7z",
 				"files": {
 					"libmedian.dll": [
 						"libmedian.dll",
@@ -113,7 +113,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-median/releases/download/v1/vapoursynth-median-v1-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-median/releases/download/v1/vapoursynth-median-v1-win64.7z",
 				"files": {
 					"libmedian.dll": [
 						"libmedian.dll",

--- a/local/minideen.json
+++ b/local/minideen.json
@@ -2,18 +2,18 @@
 	"name": "MiniDeen",
 	"type": "VSPlugin",
 	"description": "MiniDeen is a spatial denoising filter. It replaces every pixel with the average of its neighbourhood. This is a port of the 'a2d' method from the Avisynth plugin Deen, version beta 2.",
-	"website": "https://github.com/dubhater/vapoursynth-minideen",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-minideen",
 	"doom9": "https://forum.doom9.org/showthread.php?t=175587",
 	"category": "Denoising",
 	"identifier": "com.nodame.minideen",
 	"namespace": "minideen",
-	"github": "https://github.com/dubhater/vapoursynth-minideen",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-minideen",
 	"releases": [
 		{
 			"version": "v2",
 			"published": "2021-03-27T19:47:53Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-minideen/releases/download/v2/vapoursynth-minideen-v2-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-minideen/releases/download/v2/vapoursynth-minideen-v2-win32.7z",
 				"files": {
 					"libminideen.dll": [
 						"libminideen.dll",
@@ -22,7 +22,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-minideen/releases/download/v2/vapoursynth-minideen-v2-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-minideen/releases/download/v2/vapoursynth-minideen-v2-win64.7z",
 				"files": {
 					"libminideen.dll": [
 						"libminideen.dll",
@@ -53,7 +53,7 @@
 			"version": "v1",
 			"published": "2018-07-10T13:43:12Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-minideen/releases/download/v1/vapoursynth-minideen-v1-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-minideen/releases/download/v1/vapoursynth-minideen-v1-win32.7z",
 				"files": {
 					"libminideen.dll": [
 						"libminideen.dll",
@@ -62,7 +62,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-minideen/releases/download/v1/vapoursynth-minideen-v1-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-minideen/releases/download/v1/vapoursynth-minideen-v1-win64.7z",
 				"files": {
 					"libminideen.dll": [
 						"libminideen.dll",

--- a/local/motionmask.json
+++ b/local/motionmask.json
@@ -2,12 +2,12 @@
 	"name": "MotionMask",
 	"type": "VSPlugin",
 	"description": "MotionMask creates a mask of moving pixels. Every output pixel will be set to the absolute difference between the current frame and the previous frame.",
-	"website": "https://github.com/dubhater/vapoursynth-motionmask",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-motionmask",
 	"doom9": "https://forum.doom9.org/showthread.php?t=175587",
 	"category": "Other",
 	"identifier": "com.nodame.motionmask",
 	"namespace": "motionmask",
-	"github": "https://github.com/dubhater/vapoursynth-motionmask",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-motionmask",
 	"releases": [
 		{
 			"version": "git:ed86b06",
@@ -44,7 +44,7 @@
 			"version": "v2",
 			"published": "2018-06-20T09:49:37Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-motionmask/releases/download/v2/vapoursynth-motionmask-v2-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-motionmask/releases/download/v2/vapoursynth-motionmask-v2-win32.7z",
 				"files": {
 					"libmotionmask.dll": [
 						"libmotionmask.dll",
@@ -53,7 +53,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-motionmask/releases/download/v2/vapoursynth-motionmask-v2-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-motionmask/releases/download/v2/vapoursynth-motionmask-v2-win64.7z",
 				"files": {
 					"libmotionmask.dll": [
 						"libmotionmask.dll",
@@ -66,7 +66,7 @@
 			"version": "v1",
 			"published": "2018-06-19T18:15:24Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-motionmask/releases/download/v1/vapoursynth-motionmask-v1-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-motionmask/releases/download/v1/vapoursynth-motionmask-v1-win32.7z",
 				"files": {
 					"libmotionmask.dll": [
 						"libmotionmask.dll",
@@ -75,7 +75,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-motionmask/releases/download/v1/vapoursynth-motionmask-v1-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-motionmask/releases/download/v1/vapoursynth-motionmask-v1-win64.7z",
 				"files": {
 					"libmotionmask.dll": [
 						"libmotionmask.dll",

--- a/local/msmoosh.json
+++ b/local/msmoosh.json
@@ -2,18 +2,18 @@
 	"name": "MSmoosh",
 	"type": "VSPlugin",
 	"description": "High quality bitdepth, colorspace conversion and resizing",
-	"website": "https://github.com/dubhater/vapoursynth-msmoosh",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-msmoosh",
 	"doom9": "https://forum.doom9.org/showthread.php?t=171159",
 	"category": "Other",
 	"identifier": "com.nodame.msmoosh",
 	"namespace": "msmoosh",
-	"github": "https://github.com/dubhater/vapoursynth-msmoosh",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-msmoosh",
 	"releases": [
 		{
 			"version": "v1.1",
 			"published": "2014-09-26T11:51:32Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-msmoosh/releases/download/v1.1/vapoursynth-msmoosh-v1.1-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-msmoosh/releases/download/v1.1/vapoursynth-msmoosh-v1.1-win32.7z",
 				"files": {
 					"libmsmoosh.dll": [
 						"libmsmoosh.dll",
@@ -22,7 +22,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-msmoosh/releases/download/v1.1/vapoursynth-msmoosh-v1.1-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-msmoosh/releases/download/v1.1/vapoursynth-msmoosh-v1.1-win64.7z",
 				"files": {
 					"libmsmoosh.dll": [
 						"libmsmoosh.dll",
@@ -62,7 +62,7 @@
 			"version": "v1.0",
 			"published": "2014-09-09T19:06:44Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-msmoosh/releases/download/v1.0/vapoursynth-msmoosh-v1.0-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-msmoosh/releases/download/v1.0/vapoursynth-msmoosh-v1.0-win32.7z",
 				"files": {
 					"libmsmoosh.dll": [
 						"libmsmoosh.dll",
@@ -71,7 +71,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-msmoosh/releases/download/v1.0/vapoursynth-msmoosh-v1.0-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-msmoosh/releases/download/v1.0/vapoursynth-msmoosh-v1.0-win64.7z",
 				"files": {
 					"libmsmoosh.dll": [
 						"libmsmoosh.dll",

--- a/local/mv.json
+++ b/local/mv.json
@@ -2,12 +2,12 @@
 	"name": "MVTools",
 	"type": "VSPlugin",
 	"description": "MVTools port",
-	"website": "https://github.com/dubhater/vapoursynth-mvtools",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools",
 	"doom9": "https://forum.doom9.org/showthread.php?t=171207",
 	"category": "Other",
 	"identifier": "com.nodame.mvtools",
 	"namespace": "mv",
-	"github": "https://github.com/dubhater/vapoursynth-mvtools",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools",
 	"dependencies": [
 		"org.fftw.fftw3"
 	],
@@ -16,7 +16,7 @@
 			"version": "v24",
 			"published": "2024-08-05T22:12:15Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v24/vapoursynth-mvtools-v24-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v24/vapoursynth-mvtools-v24-win32.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -25,7 +25,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v24/vapoursynth-mvtools-v24-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v24/vapoursynth-mvtools-v24-win64.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -78,7 +78,7 @@
 			"version": "v23",
 			"published": "2020-05-08T16:22:53Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v23/vapoursynth-mvtools-v23-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v23/vapoursynth-mvtools-v23-win32.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -87,7 +87,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v23/vapoursynth-mvtools-v23-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v23/vapoursynth-mvtools-v23-win64.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -100,7 +100,7 @@
 			"version": "v22",
 			"published": "2020-05-04T16:43:04Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v22/vapoursynth-mvtools-v22-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v22/vapoursynth-mvtools-v22-win32.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -109,7 +109,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v22/vapoursynth-mvtools-v22-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v22/vapoursynth-mvtools-v22-win64.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -122,7 +122,7 @@
 			"version": "v21",
 			"published": "2019-03-13T15:25:22Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v21/vapoursynth-mvtools-v21-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v21/vapoursynth-mvtools-v21-win32.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -131,7 +131,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v21/vapoursynth-mvtools-v21-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v21/vapoursynth-mvtools-v21-win64.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -144,7 +144,7 @@
 			"version": "v20",
 			"published": "2018-07-09T15:00:51Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v20/vapoursynth-mvtools-v20-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v20/vapoursynth-mvtools-v20-win32.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -153,7 +153,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v20/vapoursynth-mvtools-v20-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v20/vapoursynth-mvtools-v20-win64.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -166,7 +166,7 @@
 			"version": "v19",
 			"published": "2017-06-07T18:37:37Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v19/vapoursynth-mvtools-v19-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v19/vapoursynth-mvtools-v19-win32.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -175,7 +175,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v19/vapoursynth-mvtools-v19-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v19/vapoursynth-mvtools-v19-win64.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -188,7 +188,7 @@
 			"version": "v18",
 			"published": "2017-04-14T13:39:08Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v18/vapoursynth-mvtools-v18-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v18/vapoursynth-mvtools-v18-win32.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -197,7 +197,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v18/vapoursynth-mvtools-v18-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v18/vapoursynth-mvtools-v18-win64.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -210,7 +210,7 @@
 			"version": "v17",
 			"published": "2016-10-23T13:25:46Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v17/vapoursynth-mvtools-v17-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v17/vapoursynth-mvtools-v17-win32.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -219,7 +219,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v17/vapoursynth-mvtools-v17-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v17/vapoursynth-mvtools-v17-win64.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -232,7 +232,7 @@
 			"version": "v16",
 			"published": "2016-07-09T17:16:26Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v16/vapoursynth-mvtools-v16-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v16/vapoursynth-mvtools-v16-win32.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -241,7 +241,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v16/vapoursynth-mvtools-v16-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v16/vapoursynth-mvtools-v16-win64.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -254,7 +254,7 @@
 			"version": "v15",
 			"published": "2016-07-01T18:19:01Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v15/vapoursynth-mvtools-v15-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v15/vapoursynth-mvtools-v15-win32.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -263,7 +263,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v15/vapoursynth-mvtools-v15-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v15/vapoursynth-mvtools-v15-win64.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -276,7 +276,7 @@
 			"version": "v14",
 			"published": "2016-06-22T10:42:29Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v14/vapoursynth-mvtools-v14-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v14/vapoursynth-mvtools-v14-win32.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -285,7 +285,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v14/vapoursynth-mvtools-v14-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v14/vapoursynth-mvtools-v14-win64.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -298,7 +298,7 @@
 			"version": "v13",
 			"published": "2016-04-08T19:22:38Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v13/vapoursynth-mvtools-v13-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v13/vapoursynth-mvtools-v13-win32.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -307,7 +307,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v13/vapoursynth-mvtools-v13-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v13/vapoursynth-mvtools-v13-win64.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -320,7 +320,7 @@
 			"version": "v12",
 			"published": "2016-03-18T21:04:43Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v12/vapoursynth-mvtools-v12-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v12/vapoursynth-mvtools-v12-win32.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -329,7 +329,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v12/vapoursynth-mvtools-v12-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v12/vapoursynth-mvtools-v12-win64.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -342,7 +342,7 @@
 			"version": "v11",
 			"published": "2016-02-01T13:24:08Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v11/vapoursynth-mvtools-v11-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v11/vapoursynth-mvtools-v11-win32.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -351,7 +351,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v11/vapoursynth-mvtools-v11-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v11/vapoursynth-mvtools-v11-win64.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -364,7 +364,7 @@
 			"version": "v10",
 			"published": "2016-01-18T12:03:21Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v10/vapoursynth-mvtools-v10-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v10/vapoursynth-mvtools-v10-win32.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -373,7 +373,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v10/vapoursynth-mvtools-v10-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v10/vapoursynth-mvtools-v10-win64.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -386,7 +386,7 @@
 			"version": "v9",
 			"published": "2015-05-24T14:30:16Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v9/vapoursynth-mvtools-v9-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v9/vapoursynth-mvtools-v9-win32.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -395,7 +395,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v9/vapoursynth-mvtools-v9-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v9/vapoursynth-mvtools-v9-win64.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -408,7 +408,7 @@
 			"version": "v8",
 			"published": "2015-03-09T22:37:45Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v8/vapoursynth-mvtools-v8-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v8/vapoursynth-mvtools-v8-win32.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -417,7 +417,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v8/vapoursynth-mvtools-v8-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v8/vapoursynth-mvtools-v8-win64.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -430,7 +430,7 @@
 			"version": "v7",
 			"published": "2015-02-15T10:08:45Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v7/vapoursynth-mvtools-v7-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v7/vapoursynth-mvtools-v7-win32.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -439,7 +439,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v7/vapoursynth-mvtools-v7-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v7/vapoursynth-mvtools-v7-win64.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -452,7 +452,7 @@
 			"version": "v6",
 			"published": "2015-01-30T20:13:33Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v6/vapoursynth-mvtools-v6-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v6/vapoursynth-mvtools-v6-win32.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -461,7 +461,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v6/vapoursynth-mvtools-v6-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v6/vapoursynth-mvtools-v6-win64.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -474,7 +474,7 @@
 			"version": "v5",
 			"published": "2015-01-02T12:40:26Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v5/vapoursynth-mvtools-v5-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v5/vapoursynth-mvtools-v5-win32.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -483,7 +483,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v5/vapoursynth-mvtools-v5-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v5/vapoursynth-mvtools-v5-win64.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -496,7 +496,7 @@
 			"version": "v4",
 			"published": "2014-10-09T10:58:55Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v4/vapoursynth-mvtools-v4-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v4/vapoursynth-mvtools-v4-win32.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -505,7 +505,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v4/vapoursynth-mvtools-v4-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v4/vapoursynth-mvtools-v4-win64.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -518,7 +518,7 @@
 			"version": "v3",
 			"published": "2014-10-03T14:02:41Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v3/vapoursynth-mvtools-v3-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v3/vapoursynth-mvtools-v3-win32.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -527,7 +527,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v3/vapoursynth-mvtools-v3-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v3/vapoursynth-mvtools-v3-win64.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -540,7 +540,7 @@
 			"version": "v2.0",
 			"published": "2014-09-28T10:45:36Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v2.0/vapoursynth-mvtools-v2.0-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v2.0/vapoursynth-mvtools-v2.0-win32.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -549,7 +549,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v2.0/vapoursynth-mvtools-v2.0-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v2.0/vapoursynth-mvtools-v2.0-win64.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -562,7 +562,7 @@
 			"version": "v1.1",
 			"published": "2014-09-22T18:38:47Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v1.1/vapoursynth-mvtools-v1.1-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v1.1/vapoursynth-mvtools-v1.1-win32.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -571,7 +571,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v1.1/vapoursynth-mvtools-v1.1-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v1.1/vapoursynth-mvtools-v1.1-win64.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -584,7 +584,7 @@
 			"version": "v1.0",
 			"published": "2014-09-21T20:35:27Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v1.0/vapoursynth-mvtools-v1.0-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v1.0/vapoursynth-mvtools-v1.0-win32.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",
@@ -593,7 +593,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-mvtools/releases/download/v1.0/vapoursynth-mvtools-v1.0-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-mvtools/releases/download/v1.0/vapoursynth-mvtools-v1.0-win64.7z",
 				"files": {
 					"libmvtools.dll": [
 						"libmvtools.dll",

--- a/local/neo_minideen.json
+++ b/local/neo_minideen.json
@@ -2,7 +2,7 @@
 	"name": "Neo MiniDeen",
 	"type": "VSPlugin",
 	"description": "MiniDeen is a spatial denoising filter. It replaces every pixel with the average of its neighbourhood.",
-	"website": "https://github.com/dubhater/vapoursynth-minideen",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-minideen",
 	"github": "https://github.com/HomeOfAviSynthPlusEvolution/MiniDeen",
 	"doom9": "https://forum.doom9.org/showthread.php?t=176554",
 	"category": "Denoising",

--- a/local/nnedi3.json
+++ b/local/nnedi3.json
@@ -2,12 +2,12 @@
 	"name": "NNEDI3",
 	"type": "VSPlugin",
 	"description": "Field interpolator/deinterlacer",
-	"website": "https://github.com/dubhater/vapoursynth-nnedi3",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3",
 	"doom9": "https://forum.doom9.org/showthread.php?t=166434",
 	"category": "Deinterlacing",
 	"identifier": "com.deinterlace.nnedi3",
 	"namespace": "nnedi3",
-	"github": "https://github.com/dubhater/vapoursynth-nnedi3",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3",
 	"dependencies": [
 		"com.deinterlace.nnedi3.weights"
 	],
@@ -16,7 +16,7 @@
 			"version": "v12",
 			"published": "2018-09-29T16:09:17Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v12/vapoursynth-nnedi3-v12-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v12/vapoursynth-nnedi3-v12-win32.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -25,7 +25,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v12/vapoursynth-nnedi3-v12-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v12/vapoursynth-nnedi3-v12-win64.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -65,7 +65,7 @@
 			"version": "v11",
 			"published": "2017-01-19T14:09:25Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v11/vapoursynth-nnedi3-v11-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v11/vapoursynth-nnedi3-v11-win32.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -74,7 +74,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v11/vapoursynth-nnedi3-v11-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v11/vapoursynth-nnedi3-v11-win64.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -87,7 +87,7 @@
 			"version": "v10",
 			"published": "2016-08-27T13:13:12Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v10/vapoursynth-nnedi3-v10-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v10/vapoursynth-nnedi3-v10-win32.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -96,7 +96,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v10/vapoursynth-nnedi3-v10-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v10/vapoursynth-nnedi3-v10-win64.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -109,7 +109,7 @@
 			"version": "v9",
 			"published": "2016-08-23T16:38:03Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v9/vapoursynth-nnedi3-v9-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v9/vapoursynth-nnedi3-v9-win32.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -118,7 +118,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v9/vapoursynth-nnedi3-v9-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v9/vapoursynth-nnedi3-v9-win64.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -131,7 +131,7 @@
 			"version": "v8",
 			"published": "2016-01-24T12:19:16Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v8/vapoursynth-nnedi3-v8-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v8/vapoursynth-nnedi3-v8-win32.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -140,7 +140,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v8/vapoursynth-nnedi3-v8-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v8/vapoursynth-nnedi3-v8-win64.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -153,7 +153,7 @@
 			"version": "v7",
 			"published": "2015-09-08T20:37:15Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v7/vapoursynth-nnedi3-v7-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v7/vapoursynth-nnedi3-v7-win32.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -162,7 +162,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v7/vapoursynth-nnedi3-v7-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v7/vapoursynth-nnedi3-v7-win64.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -175,7 +175,7 @@
 			"version": "v6",
 			"published": "2015-09-08T10:12:45Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v6/vapoursynth-nnedi3-v6-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v6/vapoursynth-nnedi3-v6-win32.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -184,7 +184,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v6/vapoursynth-nnedi3-v6-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v6/vapoursynth-nnedi3-v6-win64.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -197,7 +197,7 @@
 			"version": "v5",
 			"published": "2015-04-22T18:26:22Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v5/vapoursynth-nnedi3-v5-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v5/vapoursynth-nnedi3-v5-win32.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -206,7 +206,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v5/vapoursynth-nnedi3-v5-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v5/vapoursynth-nnedi3-v5-win64.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -219,7 +219,7 @@
 			"version": "v4",
 			"published": "2015-03-09T18:55:08Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v4/vapoursynth-nnedi3-v4-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v4/vapoursynth-nnedi3-v4-win32.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -228,7 +228,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v4/vapoursynth-nnedi3-v4-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v4/vapoursynth-nnedi3-v4-win64.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -241,7 +241,7 @@
 			"version": "v3",
 			"published": "2015-02-22T19:59:30Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v3/vapoursynth-nnedi3-v3-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v3/vapoursynth-nnedi3-v3-win32.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -250,7 +250,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v3/vapoursynth-nnedi3-v3-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v3/vapoursynth-nnedi3-v3-win64.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -263,7 +263,7 @@
 			"version": "v2.1",
 			"published": "2014-08-24T17:22:21Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v2.1/vapoursynth-nnedi3-v2.1-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v2.1/vapoursynth-nnedi3-v2.1-win32.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -272,7 +272,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v2.1/vapoursynth-nnedi3-v2.1-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v2.1/vapoursynth-nnedi3-v2.1-win64.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -285,7 +285,7 @@
 			"version": "v2.0",
 			"published": "2014-08-19T08:35:23Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v2.0/vapoursynth-nnedi3-v2.0-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v2.0/vapoursynth-nnedi3-v2.0-win32.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -294,7 +294,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v2.0/vapoursynth-nnedi3-v2.0-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v2.0/vapoursynth-nnedi3-v2.0-win64.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -307,7 +307,7 @@
 			"version": "v1.1",
 			"published": "2013-12-15T20:03:42Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v1.1/vapoursynth-nnedi3-v1.1-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v1.1/vapoursynth-nnedi3-v1.1-win64.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -316,7 +316,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v1.1/vapoursynth-nnedi3-v1.1-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v1.1/vapoursynth-nnedi3-v1.1-win64.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -329,7 +329,7 @@
 			"version": "v1.0",
 			"published": "2013-09-28T20:39:56Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v1.0/vapoursynth-nnedi3-v1.0-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v1.0/vapoursynth-nnedi3-v1.0-win32.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",
@@ -338,7 +338,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-nnedi3/releases/download/v1.0/vapoursynth-nnedi3-v1.0-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-nnedi3/releases/download/v1.0/vapoursynth-nnedi3-v1.0-win64.7z",
 				"files": {
 					"libnnedi3.dll": [
 						"libnnedi3.dll",

--- a/local/nrdb.json
+++ b/local/nrdb.json
@@ -2,7 +2,7 @@
 	"name": "NRDB",
 	"type": "PyScript",
 	"description": "NRDB is a debanding function. It removes the noise in the input clip, debands, and adds the noise back. This is a port of the Avisynth function of the same name.",
-	"github": "https://github.com/dubhater/vapoursynth-nrdb",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-nrdb",
 	"category": "Other",
 	"identifier": "nrdb",
 	"modulename": "nrdb",
@@ -15,10 +15,10 @@
 			"version": "git:dd2f56a",
 			"published": "2022-02-05T14:16:48Z",
 			"script": {
-				"url": "https://api.github.com/repos/dubhater/vapoursynth-nrdb/zipball/dd2f56a2e34cf73b74f34543479a68a6bc591c81",
+				"url": "https://api.github.com/repos/dubhatervapoursynth/vapoursynth-nrdb/zipball/dd2f56a2e34cf73b74f34543479a68a6bc591c81",
 				"files": {
 					"NRDB.py": [
-						"dubhater-vapoursynth-nrdb-dd2f56a/NRDB.py",
+						"dubhatervapoursynth-vapoursynth-nrdb-dd2f56a/NRDB.py",
 						"f54696461da6f20aed47dde50d8318f0a738c07dc7bc2d01032f7d85548957d0"
 					]
 				}
@@ -28,10 +28,10 @@
 			"version": "v2",
 			"published": "2020-05-06T17:53:52Z",
 			"script": {
-				"url": "https://api.github.com/repos/dubhater/vapoursynth-nrdb/zipball/v2",
+				"url": "https://api.github.com/repos/dubhatervapoursynth/vapoursynth-nrdb/zipball/v2",
 				"files": {
 					"NRDB.py": [
-						"dubhater-vapoursynth-nrdb-236b729/NRDB.py",
+						"dubhatervapoursynth-vapoursynth-nrdb-236b729/NRDB.py",
 						"6f74ebc5da4a157a51b8599c3d2be0040b2d4f50b7a26b8a4794948478c7dc3d"
 					]
 				}
@@ -41,10 +41,10 @@
 			"version": "v1",
 			"published": "2020-05-01T16:57:46Z",
 			"script": {
-				"url": "https://api.github.com/repos/dubhater/vapoursynth-nrdb/zipball/v1",
+				"url": "https://api.github.com/repos/dubhatervapoursynth/vapoursynth-nrdb/zipball/v1",
 				"files": {
 					"NRDB.py": [
-						"dubhater-vapoursynth-nrdb-951f7cd/NRDB.py",
+						"dubhatervapoursynth-vapoursynth-nrdb-951f7cd/NRDB.py",
 						"f8dd213ebe0192f81485fad54d2da411d36da22879ef377fe6816d7947de3dfe"
 					]
 				}

--- a/local/rainbowsmooth.json
+++ b/local/rainbowsmooth.json
@@ -2,12 +2,12 @@
 	"name": "RainbowSmooth",
 	"type": "PyScript",
 	"description": "RainbowSmooth is a script which adds edge detection to SmoothUV. It is a port of the Avisynth function rainbow_smooth()",
-	"website": "https://github.com/dubhater/vapoursynth-smoothuv",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-smoothuv",
 	"doom9": "https://forum.doom9.org/showthread.php?t=175520",
 	"category": "Dot Crawl and Rainbows",
 	"identifier": "rainbowsmooth",
 	"modulename": "RainbowSmooth",
-	"github": "https://github.com/dubhater/vapoursynth-smoothuv",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-smoothuv",
 	"updatemode": "git-commits",
 	"dependencies": [
 		"com.nodame.smoothuv",
@@ -19,10 +19,10 @@
 			"version": "git:d75886e",
 			"published": "2022-02-22T15:53:59Z",
 			"script": {
-				"url": "https://api.github.com/repos/dubhater/vapoursynth-smoothuv/zipball/d75886e6876c7ec45010cc735d69985bab3936df",
+				"url": "https://api.github.com/repos/dubhatervapoursynth/vapoursynth-smoothuv/zipball/d75886e6876c7ec45010cc735d69985bab3936df",
 				"files": {
 					"RainbowSmooth.py": [
-						"dubhater-vapoursynth-smoothuv-d75886e/RainbowSmooth.py",
+						"dubhatervapoursynth-vapoursynth-smoothuv-d75886e/RainbowSmooth.py",
 						"6dc54316dcff140864bef8f576d98021ba6ab1502fb09d80114a5a8ee1762de7"
 					]
 				}
@@ -32,10 +32,10 @@
 			"version": "v2",
 			"published": "2018-07-08T19:38:32Z",
 			"script": {
-				"url": "https://api.github.com/repos/dubhater/vapoursynth-smoothuv/zipball/v2",
+				"url": "https://api.github.com/repos/dubhatervapoursynth/vapoursynth-smoothuv/zipball/v2",
 				"files": {
 					"RainbowSmooth.py": [
-						"dubhater-vapoursynth-smoothuv-64e5c8f/RainbowSmooth.py",
+						"dubhatervapoursynth-vapoursynth-smoothuv-64e5c8f/RainbowSmooth.py",
 						"3f058ef1d5abe2201564d0aad0142422476b6b10daa83c43c87d0e496f8c5864"
 					]
 				}
@@ -45,10 +45,10 @@
 			"version": "v1",
 			"published": "2018-06-10T20:18:39Z",
 			"script": {
-				"url": "https://api.github.com/repos/dubhater/vapoursynth-smoothuv/zipball/v1",
+				"url": "https://api.github.com/repos/dubhatervapoursynth/vapoursynth-smoothuv/zipball/v1",
 				"files": {
 					"RainbowSmooth.py": [
-						"dubhater-vapoursynth-smoothuv-b9b78ed/RainbowSmooth.py",
+						"dubhatervapoursynth-vapoursynth-smoothuv-b9b78ed/RainbowSmooth.py",
 						"3f058ef1d5abe2201564d0aad0142422476b6b10daa83c43c87d0e496f8c5864"
 					]
 				}

--- a/local/sangnom.json
+++ b/local/sangnom.json
@@ -4,7 +4,7 @@
 	"description": "SangNom is a single field deinterlacer using edge-directed interpolation but nowadays it's mainly used in anti-aliasing scripts.",
 	"website": "https://bitbucket.org/James1201/vapoursynth-sangnom",
 	"doom9": "https://forum.doom9.org/showthread.php?t=173752",
-	"github": "https://github.com/dubhater/vapoursynth-sangnom",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-sangnom",
 	"category": "Deinterlacing",
 	"identifier": "com.mio.sangnom",
 	"namespace": "sangnom",
@@ -13,7 +13,7 @@
 			"version": "r42",
 			"published": "2020-08-03T09:06:54Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-sangnom/releases/download/r42/vapoursynth-sangnom-r42-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-sangnom/releases/download/r42/vapoursynth-sangnom-r42-win32.7z",
 				"files": {
 					"libsangnom.dll": [
 						"libsangnom.dll",
@@ -22,7 +22,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-sangnom/releases/download/r42/vapoursynth-sangnom-r42-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-sangnom/releases/download/r42/vapoursynth-sangnom-r42-win64.7z",
 				"files": {
 					"libsangnom.dll": [
 						"libsangnom.dll",
@@ -62,7 +62,7 @@
 			"version": "r41",
 			"published": "2019-03-14T17:37:21Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-sangnom/releases/download/r41/vapoursynth-sangnom-r41-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-sangnom/releases/download/r41/vapoursynth-sangnom-r41-win32.7z",
 				"files": {
 					"libsangnom.dll": [
 						"libsangnom.dll",
@@ -71,7 +71,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-sangnom/releases/download/r41/vapoursynth-sangnom-r41-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-sangnom/releases/download/r41/vapoursynth-sangnom-r41-win64.7z",
 				"files": {
 					"libsangnom.dll": [
 						"libsangnom.dll",

--- a/local/scxvid.json
+++ b/local/scxvid.json
@@ -2,17 +2,17 @@
 	"name": "Scxvid",
 	"type": "VSPlugin",
 	"description": "Scene change detection plugin for VapourSynth, using xvidcore.",
-	"website": "https://github.com/dubhater/vapoursynth-scxvid",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-scxvid",
 	"category": "Other",
 	"identifier": "com.nodame.scxvid",
 	"namespace": "scxvid",
-	"github": "https://github.com/dubhater/vapoursynth-scxvid",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-scxvid",
 	"releases": [
 		{
 			"version": "v1",
 			"published": "2014-12-24T21:23:24Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-scxvid/releases/download/v1/vapoursynth-scxvid-v1-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-scxvid/releases/download/v1/vapoursynth-scxvid-v1-win32.7z",
 				"files": {
 					"libscxvid.dll": [
 						"libscxvid.dll",
@@ -21,7 +21,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-scxvid/releases/download/v1/vapoursynth-scxvid-v1-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-scxvid/releases/download/v1/vapoursynth-scxvid-v1-win64.7z",
 				"files": {
 					"libscxvid.dll": [
 						"libscxvid.dll",

--- a/local/smoothuv.json
+++ b/local/smoothuv.json
@@ -2,18 +2,18 @@
 	"name": "SmoothUV",
 	"type": "VSPlugin",
 	"description": "A spatial derainbow filter",
-	"website": "https://github.com/dubhater/vapoursynth-smoothuv",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-smoothuv",
 	"doom9": "https://forum.doom9.org/showthread.php?t=175520",
 	"category": "Dot Crawl and Rainbows",
 	"identifier": "com.nodame.smoothuv",
 	"namespace": "smoothuv",
-	"github": "https://github.com/dubhater/vapoursynth-smoothuv",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-smoothuv",
 	"releases": [
 		{
 			"version": "v3",
 			"published": "2022-06-01T16:40:59Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-smoothuv/releases/download/v3/vapoursynth-smoothuv-v3-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-smoothuv/releases/download/v3/vapoursynth-smoothuv-v3-win32.7z",
 				"files": {
 					"libsmoothuv.dll": [
 						"libsmoothuv.dll",
@@ -22,7 +22,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-smoothuv/releases/download/v3/vapoursynth-smoothuv-v3-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-smoothuv/releases/download/v3/vapoursynth-smoothuv-v3-win64.7z",
 				"files": {
 					"libsmoothuv.dll": [
 						"libsmoothuv.dll",
@@ -44,7 +44,7 @@
 			"version": "v2",
 			"published": "2018-07-08T19:38:32Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-smoothuv/releases/download/v2/vapoursynth-smoothuv-v2-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-smoothuv/releases/download/v2/vapoursynth-smoothuv-v2-win32.7z",
 				"files": {
 					"libsmoothuv.dll": [
 						"libsmoothuv.dll",
@@ -53,7 +53,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-smoothuv/releases/download/v2/vapoursynth-smoothuv-v2-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-smoothuv/releases/download/v2/vapoursynth-smoothuv-v2-win64.7z",
 				"files": {
 					"libsmoothuv.dll": [
 						"libsmoothuv.dll",
@@ -66,7 +66,7 @@
 			"version": "v1",
 			"published": "2018-06-10T20:18:39Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-smoothuv/releases/download/v1/vapoursynth-smoothuv-v1-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-smoothuv/releases/download/v1/vapoursynth-smoothuv-v1-win32.7z",
 				"files": {
 					"libsmoothuv.dll": [
 						"libsmoothuv.dll",
@@ -75,7 +75,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-smoothuv/releases/download/v1/vapoursynth-smoothuv-v1-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-smoothuv/releases/download/v1/vapoursynth-smoothuv-v1-win64.7z",
 				"files": {
 					"libsmoothuv.dll": [
 						"libsmoothuv.dll",

--- a/local/ssiq.json
+++ b/local/ssiq.json
@@ -2,17 +2,17 @@
 	"name": "SSIQ",
 	"type": "VSPlugin",
 	"description": "Spatial derainbowing filter",
-	"website": "https://github.com/dubhater/vapoursynth-ssiq",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-ssiq",
 	"category": "Dot Crawl and Rainbows",
 	"identifier": "com.nodame.ssiq",
 	"namespace": "ssiq",
-	"github": "https://github.com/dubhater/vapoursynth-ssiq",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-ssiq",
 	"releases": [
 		{
 			"version": "v1.0",
 			"published": "2013-10-01T09:25:56Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-ssiq/releases/download/v1.0/vapoursynth-ssiq-v1.0-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-ssiq/releases/download/v1.0/vapoursynth-ssiq-v1.0-win32.7z",
 				"files": {
 					"libssiq.dll": [
 						"libssiq.dll",
@@ -21,7 +21,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-ssiq/releases/download/v1.0/vapoursynth-ssiq-v1.0-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-ssiq/releases/download/v1.0/vapoursynth-ssiq-v1.0-win64.7z",
 				"files": {
 					"libssiq.dll": [
 						"libssiq.dll",

--- a/local/tbilateral.json
+++ b/local/tbilateral.json
@@ -5,13 +5,13 @@
 	"category": "Denoising",
 	"identifier": "com.nodame.tbilateral",
 	"namespace": "tbilateral",
-	"github": "https://github.com/dubhater/vapoursynth-tbilateral",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-tbilateral",
 	"releases": [
 		{
 			"version": "v4",
 			"published": "2021-03-27T20:27:38Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-tbilateral/releases/download/v4/vapoursynth-tbilateral-v4-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-tbilateral/releases/download/v4/vapoursynth-tbilateral-v4-win32.7z",
 				"files": {
 					"libtbilateral.dll": [
 						"libtbilateral.dll",
@@ -20,7 +20,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-tbilateral/releases/download/v4/vapoursynth-tbilateral-v4-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-tbilateral/releases/download/v4/vapoursynth-tbilateral-v4-win64.7z",
 				"files": {
 					"libtbilateral.dll": [
 						"libtbilateral.dll",
@@ -60,7 +60,7 @@
 			"version": "v3",
 			"published": "2019-10-25T15:10:16Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-tbilateral/releases/download/v3/vapoursynth-tbilateral-v3-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-tbilateral/releases/download/v3/vapoursynth-tbilateral-v3-win32.7z",
 				"files": {
 					"libtbilateral.dll": [
 						"libtbilateral.dll",
@@ -69,7 +69,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-tbilateral/releases/download/v3/vapoursynth-tbilateral-v3-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-tbilateral/releases/download/v3/vapoursynth-tbilateral-v3-win64.7z",
 				"files": {
 					"libtbilateral.dll": [
 						"libtbilateral.dll",
@@ -82,7 +82,7 @@
 			"version": "v2",
 			"published": "2019-10-06T19:08:00Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-tbilateral/releases/download/v2/vapoursynth-tbilateral-v2-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-tbilateral/releases/download/v2/vapoursynth-tbilateral-v2-win32.7z",
 				"files": {
 					"libtbilateral.dll": [
 						"libtbilateral.dll",
@@ -91,7 +91,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-tbilateral/releases/download/v2/vapoursynth-tbilateral-v2-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-tbilateral/releases/download/v2/vapoursynth-tbilateral-v2-win64.7z",
 				"files": {
 					"libtbilateral.dll": [
 						"libtbilateral.dll",
@@ -104,7 +104,7 @@
 			"version": "v1",
 			"published": "2019-10-04T20:49:03Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-tbilateral/releases/download/v1/vapoursynth-tbilateral-v1-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-tbilateral/releases/download/v1/vapoursynth-tbilateral-v1-win32.7z",
 				"files": {
 					"libtbilateral.dll": [
 						"libtbilateral.dll",
@@ -113,7 +113,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-tbilateral/releases/download/v1/vapoursynth-tbilateral-v1-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-tbilateral/releases/download/v1/vapoursynth-tbilateral-v1-win64.7z",
 				"files": {
 					"libtbilateral.dll": [
 						"libtbilateral.dll",

--- a/local/tcomb.json
+++ b/local/tcomb.json
@@ -2,18 +2,18 @@
 	"name": "TComb",
 	"type": "VSPlugin",
 	"description": "A temporal comb filter, it reduces rainbowing and dot crawl artifacts in static areas of the picture",
-	"website": "https://github.com/dubhater/vapoursynth-tcomb",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-tcomb",
 	"doom9": "https://forum.doom9.org/showthread.php?t=171124",
 	"category": "Dot Crawl and Rainbows",
 	"identifier": "com.nodame.tcomb",
 	"namespace": "tcomb",
-	"github": "https://github.com/dubhater/vapoursynth-tcomb",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-tcomb",
 	"releases": [
 		{
 			"version": "v4",
 			"published": "2020-06-23T16:52:33Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-tcomb/releases/download/v4/vapoursynth-tcomb-v4-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-tcomb/releases/download/v4/vapoursynth-tcomb-v4-win32.7z",
 				"files": {
 					"libtcomb.dll": [
 						"libtcomb.dll",
@@ -22,7 +22,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-tcomb/releases/download/v4/vapoursynth-tcomb-v4-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-tcomb/releases/download/v4/vapoursynth-tcomb-v4-win64.7z",
 				"files": {
 					"libtcomb.dll": [
 						"libtcomb.dll",
@@ -62,7 +62,7 @@
 			"version": "v3",
 			"published": "2017-02-16T22:01:23Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-tcomb/releases/download/v3/vapoursynth-tcomb-v3-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-tcomb/releases/download/v3/vapoursynth-tcomb-v3-win32.7z",
 				"files": {
 					"libtcomb.dll": [
 						"libtcomb.dll",
@@ -71,7 +71,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-tcomb/releases/download/v3/vapoursynth-tcomb-v3-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-tcomb/releases/download/v3/vapoursynth-tcomb-v3-win64.7z",
 				"files": {
 					"libtcomb.dll": [
 						"libtcomb.dll",
@@ -84,7 +84,7 @@
 			"version": "v2",
 			"published": "2016-02-20T12:38:01Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-tcomb/releases/download/v2/vapoursynth-tcomb-v2-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-tcomb/releases/download/v2/vapoursynth-tcomb-v2-win32.7z",
 				"files": {
 					"libtcomb.dll": [
 						"libtcomb.dll",
@@ -93,7 +93,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-tcomb/releases/download/v2/vapoursynth-tcomb-v2-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-tcomb/releases/download/v2/vapoursynth-tcomb-v2-win64.7z",
 				"files": {
 					"libtcomb.dll": [
 						"libtcomb.dll",
@@ -106,7 +106,7 @@
 			"version": "v1.0",
 			"published": "2014-09-01T14:02:22Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-tcomb/releases/download/v1.0/vapoursynth-tcomb-v1.0-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-tcomb/releases/download/v1.0/vapoursynth-tcomb-v1.0-win32.7z",
 				"files": {
 					"libtcomb.dll": [
 						"libtcomb.dll",
@@ -115,7 +115,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-tcomb/releases/download/v1.0/vapoursynth-tcomb-v1.0-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-tcomb/releases/download/v1.0/vapoursynth-tcomb-v1.0-win64.7z",
 				"files": {
 					"libtcomb.dll": [
 						"libtcomb.dll",

--- a/local/tedgemask.json
+++ b/local/tedgemask.json
@@ -2,7 +2,7 @@
 	"name": "TEdgeMask",
 	"type": "VSPlugin",
 	"description": "TEdgeMask is an edge detection filter. This is a port of the TEdgeMask/TEMmod Avisynth plugins.",
-	"github": "https://github.com/dubhater/vapoursynth-tedgemask",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-tedgemask",
 	"doom9": "https://forum.doom9.org/showthread.php?t=176196",
 	"category": "Other",
 	"identifier": "com.nodame.tedgemask",
@@ -12,7 +12,7 @@
 			"version": "v1",
 			"published": "2019-03-13T14:16:09Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-tedgemask/releases/download/v1/vapoursynth-tedgemask-v1-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-tedgemask/releases/download/v1/vapoursynth-tedgemask-v1-win32.7z",
 				"files": {
 					"libtedgemask.dll": [
 						"libtedgemask.dll",
@@ -21,7 +21,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-tedgemask/releases/download/v1/vapoursynth-tedgemask-v1-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-tedgemask/releases/download/v1/vapoursynth-tedgemask-v1-win64.7z",
 				"files": {
 					"libtedgemask.dll": [
 						"libtedgemask.dll",

--- a/local/tivtc.json
+++ b/local/tivtc.json
@@ -4,7 +4,7 @@
 	"category": "Inverse Telecine",
 	"description": "Field matching and decimation",
 	"doom9": "https://forum.doom9.org/showthread.php?t=182536",
-	"github": "https://github.com/dubhater/vapoursynth-tivtc",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-tivtc",
 	"identifier": "com.nodame.tivtc",
 	"namespace": "tivtc",
 	"releases": [
@@ -12,7 +12,7 @@
 			"version": "v2",
 			"published": "2021-03-17T17:36:11Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-tivtc/releases/download/v2/vapoursynth-tivtc-v2-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-tivtc/releases/download/v2/vapoursynth-tivtc-v2-win32.7z",
 				"files": {
 					"libtivtc.dll": [
 						"libtivtc.dll",
@@ -21,7 +21,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-tivtc/releases/download/v2/vapoursynth-tivtc-v2-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-tivtc/releases/download/v2/vapoursynth-tivtc-v2-win64.7z",
 				"files": {
 					"libtivtc.dll": [
 						"libtivtc.dll",

--- a/local/tmedian.json
+++ b/local/tmedian.json
@@ -2,17 +2,17 @@
 	"name": "TemporalMedian",
 	"type": "VSPlugin",
 	"description": "TemporalMedian is a temporal denoising filter. It replaces every pixel with the median of its temporal neighbourhood. This filter will introduce ghosting, so use with caution.",
-	"website": "https://github.com/dubhater/vapoursynth-temporalmedian",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-temporalmedian",
 	"category": "Denoising",
 	"identifier": "com.nodame.temporalmedian",
 	"namespace": "tmedian",
-	"github": "https://github.com/dubhater/vapoursynth-temporalmedian",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-temporalmedian",
 	"releases": [
 		{
 			"version": "v1",
 			"published": "2018-07-25T11:16:03Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-temporalmedian/releases/download/v1/vapoursynth-temporalmedian-v1-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-temporalmedian/releases/download/v1/vapoursynth-temporalmedian-v1-win32.7z",
 				"files": {
 					"libtemporalmedian.dll": [
 						"libtemporalmedian.dll",
@@ -21,7 +21,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-temporalmedian/releases/download/v1/vapoursynth-temporalmedian-v1-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-temporalmedian/releases/download/v1/vapoursynth-temporalmedian-v1-win64.7z",
 				"files": {
 					"libtemporalmedian.dll": [
 						"libtemporalmedian.dll",

--- a/local/warp.json
+++ b/local/warp.json
@@ -2,18 +2,18 @@
 	"name": "AWarpSharp2",
 	"type": "VSPlugin",
 	"description": "AWarpSharp2 sharpens edges by warping them.",
-	"website": "https://github.com/dubhater/vapoursynth-awarpsharp2",
+	"website": "https://github.com/dubhatervapoursynth/vapoursynth-awarpsharp2",
 	"doom9": "https://forum.doom9.org/showthread.php?t=172721",
 	"category": "Other",
 	"identifier": "com.nodame.awarpsharp2",
 	"namespace": "warp",
-	"github": "https://github.com/dubhater/vapoursynth-awarpsharp2",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-awarpsharp2",
 	"releases": [
 		{
 			"version": "v4",
 			"published": "2018-06-15T09:39:12Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-awarpsharp2/releases/download/v4/vapoursynth-awarpsharp2-v4-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-awarpsharp2/releases/download/v4/vapoursynth-awarpsharp2-v4-win32.7z",
 				"files": {
 					"libawarpsharp2.dll": [
 						"libawarpsharp2.dll",
@@ -22,7 +22,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-awarpsharp2/releases/download/v4/vapoursynth-awarpsharp2-v4-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-awarpsharp2/releases/download/v4/vapoursynth-awarpsharp2-v4-win64.7z",
 				"files": {
 					"libawarpsharp2.dll": [
 						"libawarpsharp2.dll",
@@ -62,7 +62,7 @@
 			"version": "v3",
 			"published": "2016-08-28T19:43:08Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-awarpsharp2/releases/download/v3/vapoursynth-awarpsharp2-v3-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-awarpsharp2/releases/download/v3/vapoursynth-awarpsharp2-v3-win32.7z",
 				"files": {
 					"libawarpsharp2.dll": [
 						"libawarpsharp2.dll",
@@ -71,7 +71,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-awarpsharp2/releases/download/v3/vapoursynth-awarpsharp2-v3-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-awarpsharp2/releases/download/v3/vapoursynth-awarpsharp2-v3-win64.7z",
 				"files": {
 					"libawarpsharp2.dll": [
 						"libawarpsharp2.dll",
@@ -84,7 +84,7 @@
 			"version": "v2",
 			"published": "2016-06-10T18:03:37Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-awarpsharp2/releases/download/v2/vapoursynth-awarpsharp2-v2-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-awarpsharp2/releases/download/v2/vapoursynth-awarpsharp2-v2-win32.7z",
 				"files": {
 					"libawarpsharp2.dll": [
 						"libawarpsharp2.dll",
@@ -93,7 +93,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-awarpsharp2/releases/download/v2/vapoursynth-awarpsharp2-v2-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-awarpsharp2/releases/download/v2/vapoursynth-awarpsharp2-v2-win64.7z",
 				"files": {
 					"libawarpsharp2.dll": [
 						"libawarpsharp2.dll",
@@ -106,7 +106,7 @@
 			"version": "v1",
 			"published": "2015-10-06T19:24:24Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-awarpsharp2/releases/download/v1/vapoursynth-awarpsharp2-v1-win32.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-awarpsharp2/releases/download/v1/vapoursynth-awarpsharp2-v1-win32.7z",
 				"files": {
 					"libawarpsharp2.dll": [
 						"libawarpsharp2.dll",
@@ -115,7 +115,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-awarpsharp2/releases/download/v1/vapoursynth-awarpsharp2-v1-win64.7z",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-awarpsharp2/releases/download/v1/vapoursynth-awarpsharp2-v1-win64.7z",
 				"files": {
 					"libawarpsharp2.dll": [
 						"libawarpsharp2.dll",

--- a/local/wwxd.json
+++ b/local/wwxd.json
@@ -3,7 +3,7 @@
 	"type": "VSPlugin",
 	"category": "Other",
 	"description": "WWXD is basically Xvid's frame type decision code stuffed into a VapourSynth plugin. The output is somewhat different from Scxvid's, because Xvid's decisions are also affected by data calculated while encoding frames. ",
-	"github": "https://github.com/dubhater/vapoursynth-wwxd",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-wwxd",
 	"identifier": "com.nodame.wwxd",
 	"namespace": "wwxd",
 	"releases": [
@@ -11,7 +11,7 @@
 			"version": "v1.0",
 			"published": "2014-04-28T15:30:38Z",
 			"win32": {
-				"url": "https://github.com/dubhater/vapoursynth-wwxd/releases/download/v1.0/libwwxd32.dll",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-wwxd/releases/download/v1.0/libwwxd32.dll",
 				"files": {
 					"libwwxd32.dll": [
 						"libwwxd32.dll",
@@ -20,7 +20,7 @@
 				}
 			},
 			"win64": {
-				"url": "https://github.com/dubhater/vapoursynth-wwxd/releases/download/v1.0/libwwxd64.dll",
+				"url": "https://github.com/dubhatervapoursynth/vapoursynth-wwxd/releases/download/v1.0/libwwxd64.dll",
 				"files": {
 					"libwwxd64.dll": [
 						"libwwxd64.dll",

--- a/local/xaa.json
+++ b/local/xaa.json
@@ -5,7 +5,7 @@
 	"category": "Scripts",
 	"identifier": "xaa",
 	"modulename": "xaa",
-	"github": "https://github.com/dubhater/vapoursynth-xaa",
+	"github": "https://github.com/dubhatervapoursynth/vapoursynth-xaa",
 	"doom9": "https://forum.doom9.org/showthread.php?t=176203",
 	"dependencies": [
 		"com.holywu.eedi2",
@@ -22,10 +22,10 @@
 			"version": "v3",
 			"published": "2019-10-23T10:49:00Z",
 			"script": {
-				"url": "https://api.github.com/repos/dubhater/vapoursynth-xaa/zipball/v3",
+				"url": "https://api.github.com/repos/dubhatervapoursynth/vapoursynth-xaa/zipball/v3",
 				"files": {
 					"xaa.py": [
-						"dubhater-vapoursynth-xaa-104f39e/xaa.py",
+						"dubhatervapoursynth-vapoursynth-xaa-104f39e/xaa.py",
 						"ad05590ff8876bcdb016e31043a96c58a0eb39d93b9cced43a3987b0e930c6cc"
 					]
 				}


### PR DESCRIPTION
Sorry, the previous PR didn't replace everything.
Replacements are required in the following plugins:
astdr
dfmderainbow
limitedsharpen2
nrdb
rainbowsmooth
xaa

The rest are just for consistency.